### PR TITLE
Type safe

### DIFF
--- a/src-test/org/etools/j1939_84/bus/EchoTest.java
+++ b/src-test/org/etools/j1939_84/bus/EchoTest.java
@@ -29,7 +29,9 @@ public class EchoTest {
                     () -> Packet.create(65260, 0x0, VIN.getBytes()));
 
             assertEquals(VIN,
-                    new J1939(bus).requestMultiple(VehicleIdentificationPacket.class).findFirst()
+                    new J1939(bus).requestMultiple(VehicleIdentificationPacket.class)
+                            .flatMap(e -> e.left.stream())
+                            .findFirst()
                             .map(p1 -> new String(p1.getPacket().getBytes())).get());
         }
     }

--- a/src-test/org/etools/j1939_84/bus/RP1210Test.java
+++ b/src-test/org/etools/j1939_84/bus/RP1210Test.java
@@ -62,7 +62,9 @@ public class RP1210Test {
         long start = System.currentTimeMillis();
         Stream<Packet> read = bus.read(365, TimeUnit.DAYS);
         new J1939(bus).requestMultiple(VehicleIdentificationPacket.class)
-                .map(pa -> pa.getVin()).findAny()
+                .flatMap(pa -> pa.left.stream())
+                .map(pa -> pa.getVin())
+                .findAny()
                 .ifPresent(vin -> System.err.format(NL + NL + "VIN:%s" + NL + NL, vin));
         read// .filter(p -> p.getId() == 0xFECA || p.getId() == 0xFEEC ||
             // (p.getId() & 0xFF00) == 0xEB00

--- a/src-test/org/etools/j1939_84/bus/j1939/J1939Test.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/J1939Test.java
@@ -413,7 +413,7 @@ public class J1939Test {
                 .requestRaw(DM11ClearActiveDTCsPacket.class, request, 5500, TimeUnit.MILLISECONDS)
                 .collect(Collectors.toList());
 
-        assertEquals(9, packets.size());
+        assertEquals(8, packets.size());
     }
 
 }

--- a/src-test/org/etools/j1939_84/bus/j1939/J1939Test.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/J1939Test.java
@@ -314,7 +314,7 @@ public class J1939Test {
         Packet requestPacket = instance.createRequestPacket(DM11ClearActiveDTCsPacket.PGN, GLOBAL_ADDR);
 
         List<AcknowledgmentPacket> responses = instance.requestMultiple(AcknowledgmentPacket.class, requestPacket)
-                .flatMap(e -> e.left.stream())
+                .flatMap(e -> e.right.stream())
                 .collect(Collectors.toList());
         assertEquals(3, responses.size());
 
@@ -409,9 +409,8 @@ public class J1939Test {
                 response10));
 
         Packet request = instance.createRequestPacket(DM11ClearActiveDTCsPacket.PGN, GLOBAL_ADDR);
-        List<ParsedPacket> packets = instance
-                .requestRaw(AcknowledgmentPacket.class, request, 5500, TimeUnit.MILLISECONDS)
-                .flatMap(e -> e.left.stream())
+        List<?> packets = instance
+                .requestRaw(DM11ClearActiveDTCsPacket.class, request, 5500, TimeUnit.MILLISECONDS)
                 .collect(Collectors.toList());
 
         assertEquals(9, packets.size());

--- a/src-test/org/etools/j1939_84/bus/j1939/J1939Test.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/J1939Test.java
@@ -97,7 +97,7 @@ public class J1939Test {
         J1939 j1939 = new J1939(echoBus);
         for (int id = 0; id < 0x1FFFFF; id++) {
             Packet packet = Packet.create(id, 0x17, 11, 22, 33, 44, 55, 66, 77, 88);
-            Stream<ParsedPacket> stream = j1939.read();
+            Stream<?> stream = j1939.read();
             echoBus.send(packet);
             assertTrue("Failed on id " + id, stream.findFirst().isPresent());
         }
@@ -124,8 +124,8 @@ public class J1939Test {
         Packet packet2 = Packet.create(VehicleIdentificationPacket.PGN, 0x00, 1, 2, 3, 4, 5, 6, 7, 8);
         when(bus.read(5000, TimeUnit.DAYS)).thenReturn(Stream.of(packet1, packet2, packet1, packet2, packet1, packet2));
 
-        Stream<EngineSpeedPacket> response = instance.read(EngineSpeedPacket.class, 5000, TimeUnit.DAYS);
-        List<EngineSpeedPacket> packets = response.collect(Collectors.toList());
+        Stream<?> response = instance.read(EngineSpeedPacket.class, 5000, TimeUnit.DAYS);
+        List<?> packets = response.collect(Collectors.toList());
         assertEquals(1, packets.size());
     }
 
@@ -146,7 +146,9 @@ public class J1939Test {
                 | 0x00, BUS_ADDR, 247, spn & 0xFF, (spn >> 8) & 0xFF, (spn >> 16) & 0xFF | 31, 0xFF, 0xFF, 0xFF, 0xFF);
 
         DM30ScaledTestResultsPacket packet = instance
-                .requestPacket(requestPacket, DM30ScaledTestResultsPacket.class, 0x00, 4).orElse(null);
+                .requestPacket(requestPacket, DM30ScaledTestResultsPacket.class, 0x00, 4)
+                .flatMap(e -> e.left)
+                .orElse(null);
         assertNotNull(packet);
 
         verify(bus).send(sendPacketCaptor.capture());
@@ -170,7 +172,7 @@ public class J1939Test {
         Packet requestPacket = Packet.create(DM7CommandTestsPacket.PGN
                 | 0x00, BUS_ADDR, 247, spn & 0xFF, (spn >> 8) & 0xFF, (spn >> 16) & 0xFF | 31, 0xFF, 0xFF, 0xFF, 0xFF);
 
-        DM30ScaledTestResultsPacket packet = instance
+        Object packet = instance
                 .requestPacket(requestPacket, DM30ScaledTestResultsPacket.class, 0x00, 3).orElse(null);
         assertNull(packet);
 
@@ -197,7 +199,7 @@ public class J1939Test {
         Packet requestPacket = Packet.create(DM7CommandTestsPacket.PGN
                 | 0x00, BUS_ADDR, 247, spn & 0xFF, (spn >> 8) & 0xFF, (spn >> 16) & 0xFF | 31, 0xFF, 0xFF, 0xFF, 0xFF);
 
-        DM30ScaledTestResultsPacket packet = instance
+        Object packet = instance
                 .requestPacket(requestPacket, DM30ScaledTestResultsPacket.class, 0x00, 3).orElse(null);
         assertNotNull(packet);
 
@@ -209,7 +211,7 @@ public class J1939Test {
 
     @Test
     public void testRequestMultipleByClassHandlesException() throws Exception {
-        Stream<TestPacket> response = instance.requestMultiple(TestPacket.class);
+        Stream<?> response = instance.requestMultiple(TestPacket.class);
         assertEquals(0, response.count());
     }
 
@@ -223,7 +225,8 @@ public class J1939Test {
 
         Packet request = instance.createRequestPacket(VehicleIdentificationPacket.PGN, 0xFF);
 
-        Stream<VehicleIdentificationPacket> response = instance.requestMultiple(VehicleIdentificationPacket.class);
+        Stream<VehicleIdentificationPacket> response = instance.requestMultiple(VehicleIdentificationPacket.class)
+                .flatMap(e -> e.left.stream());
         List<VehicleIdentificationPacket> packets = response.collect(Collectors.toList());
         assertEquals(3, packets.size());
         assertEquals("EngineVIN", packets.get(0).getVin());
@@ -239,7 +242,7 @@ public class J1939Test {
                 .thenThrow(new BusException("Testing"));
         Packet request = instance.createRequestPacket(DM5DiagnosticReadinessPacket.PGN, 0x00);
         Stream<DM5DiagnosticReadinessPacket> response = instance.requestMultiple(DM5DiagnosticReadinessPacket.class,
-                request);
+                request).flatMap(e -> e.left.stream());
         assertEquals(0, response.count());
     }
 
@@ -250,7 +253,8 @@ public class J1939Test {
 
         Packet requestPacket = instance.createRequestPacket(EngineHoursPacket.PGN, ENGINE_ADDR);
 
-        Stream<EngineHoursPacket> response = instance.requestMultiple(EngineHoursPacket.class, requestPacket);
+        Stream<EngineHoursPacket> response = instance.requestMultiple(EngineHoursPacket.class, requestPacket)
+                .flatMap(e -> e.left.stream());
         List<EngineHoursPacket> packets = response.collect(Collectors.toList());
         assertEquals(1, packets.size());
         assertEquals(3365299.25, packets.get(0).getEngineHours(), 0.0001);
@@ -261,7 +265,7 @@ public class J1939Test {
     @Test
     public void testRequestMultipleHandlesException() throws Exception {
         Stream<TestPacket> response = instance.requestMultiple(TestPacket.class,
-                Packet.create(0xEA00 | 0, 0, 0, 0 >> 8, 0 >> 16));
+                Packet.create(0xEA00 | 0, 0, 0, 0 >> 8, 0 >> 16)).flatMap(e -> e.left.stream());
         assertEquals(0, response.count());
     }
 
@@ -271,7 +275,7 @@ public class J1939Test {
                 .thenReturn(Stream.empty()).thenReturn(Stream.empty());
         Packet request = instance.createRequestPacket(VehicleIdentificationPacket.PGN, 0xFF);
         Stream<VehicleIdentificationPacket> response = instance.requestMultiple(VehicleIdentificationPacket.class,
-                request);
+                request).flatMap(e -> e.left.stream());
         assertEquals(0, response.count());
         verify(bus, times(3)).send(request);
     }
@@ -290,7 +294,7 @@ public class J1939Test {
         Packet request = instance.createRequestPacket(VehicleIdentificationPacket.PGN, 0xFF);
 
         Stream<VehicleIdentificationPacket> response = instance.requestMultiple(VehicleIdentificationPacket.class,
-                request);
+                request).flatMap(e -> e.left.stream());
         List<VehicleIdentificationPacket> packets = response.collect(Collectors.toList());
         assertEquals(1, packets.size());
         assertEquals(expected, packets.get(0).getVin());
@@ -310,6 +314,7 @@ public class J1939Test {
         Packet requestPacket = instance.createRequestPacket(DM11ClearActiveDTCsPacket.PGN, GLOBAL_ADDR);
 
         List<AcknowledgmentPacket> responses = instance.requestMultiple(AcknowledgmentPacket.class, requestPacket)
+                .flatMap(e -> e.left.stream())
                 .collect(Collectors.toList());
         assertEquals(3, responses.size());
 
@@ -336,7 +341,7 @@ public class J1939Test {
 
         Packet request = instance.createRequestPacket(VehicleIdentificationPacket.PGN, 0xFF);
         Stream<VehicleIdentificationPacket> response = instance.requestMultiple(VehicleIdentificationPacket.class,
-                request);
+                request).flatMap(e -> e.left.stream());
         List<VehicleIdentificationPacket> packets = response.collect(Collectors.toList());
         assertEquals(3, packets.size());
         assertEquals("EngineVIN", packets.get(0).getVin());
@@ -352,7 +357,7 @@ public class J1939Test {
                 .thenReturn(Stream.of(Packet.create(VehicleIdentificationPacket.PGN, 0x00, "*".getBytes(UTF8))));
         Packet request = instance.createRequestPacket(VehicleIdentificationPacket.PGN, 0xFF);
         Stream<VehicleIdentificationPacket> response = instance.requestMultiple(VehicleIdentificationPacket.class,
-                request);
+                request).flatMap(e -> e.left.stream());
         assertEquals(1, response.count());
         verify(bus, times(2)).send(request);
     }
@@ -364,7 +369,7 @@ public class J1939Test {
                 .thenReturn(Stream.of(Packet.create(VehicleIdentificationPacket.PGN, 0x00, "*".getBytes(UTF8))));
         Packet request = instance.createRequestPacket(VehicleIdentificationPacket.PGN, 0xFF);
         Stream<VehicleIdentificationPacket> response = instance.requestMultiple(VehicleIdentificationPacket.class,
-                request);
+                request).flatMap(e -> e.left.stream());
         assertEquals(1, response.count());
         verify(bus, times(3)).send(request);
     }
@@ -406,6 +411,7 @@ public class J1939Test {
         Packet request = instance.createRequestPacket(DM11ClearActiveDTCsPacket.PGN, GLOBAL_ADDR);
         List<ParsedPacket> packets = instance
                 .requestRaw(AcknowledgmentPacket.class, request, 5500, TimeUnit.MILLISECONDS)
+                .flatMap(e -> e.left.stream())
                 .collect(Collectors.toList());
 
         assertEquals(9, packets.size());

--- a/src-test/org/etools/j1939_84/controllers/part1/Step04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Step04ControllerTest.java
@@ -13,12 +13,12 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
 
 import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.bus.j1939.packets.DM24SPNSupportPacket;
-import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 import org.etools.j1939_84.bus.j1939.packets.SupportedSPN;
 import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.TestResultsListener;
@@ -139,7 +139,7 @@ public class Step04ControllerTest {
     },
              description = "Using a response that indicates that 6.1.4.2.a, 6.1.4.2.b, 6.1.4.2.c all failed, verify that the failures are in the report.")
     public void testErroredObject() {
-        List<ParsedPacket> packets = new ArrayList<>();
+        List<DM24SPNSupportPacket> packets = new ArrayList<>();
         DM24SPNSupportPacket packet1 = mock(DM24SPNSupportPacket.class);
         when(packet1.getSourceAddress()).thenReturn(0);
         packets.add(packet1);
@@ -162,7 +162,8 @@ public class Step04ControllerTest {
         when(packet4.getSupportedSpns()).thenReturn(supportedSpns);
         packets.add(packet4);
 
-        when(obdTestsModule.requestDM24Packets(any(), any())).thenReturn(new RequestResult<>(true, packets));
+        when(obdTestsModule.requestDM24Packets(any(), any()))
+                .thenReturn(new RequestResult<>(true, packets, Collections.emptyList()));
 
         List<SupportedSPN> expectedSPNs = new ArrayList<>();
         SupportedSPN supportedSpn = new SupportedSPN(new int[] { 0x00, 0x00, 0x00, 0x00 });
@@ -234,7 +235,7 @@ public class Step04ControllerTest {
     @TestDoc(value = @TestItem(verifies = "6.1.4.2.a,b,c"),
              description = "Verify that step completes without errors when none of the fail criteria are met.")
     public void testGoodObjects() {
-        List<ParsedPacket> packets = new ArrayList<>();
+        List<DM24SPNSupportPacket> packets = new ArrayList<>();
         DM24SPNSupportPacket packet1 = mock(DM24SPNSupportPacket.class);
         when(packet1.getSourceAddress()).thenReturn(0);
         packets.add(packet1);
@@ -257,7 +258,7 @@ public class Step04ControllerTest {
         when(packet4.getSupportedSpns()).thenReturn(supportedSpns);
         packets.add(packet4);
 
-        RequestResult<ParsedPacket> result = new RequestResult<>(false, packets);
+        RequestResult<DM24SPNSupportPacket> result = new RequestResult<>(false, packets, Collections.emptyList());
         when(obdTestsModule.requestDM24Packets(any(), any())).thenReturn(result);
 
         List<SupportedSPN> expectedSPNs = new ArrayList<>();

--- a/src-test/org/etools/j1939_84/controllers/part1/Step06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Step06ControllerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
 
@@ -156,7 +157,7 @@ public class Step06ControllerTest extends AbstractControllerTest {
     public void testAsteriskTerminationGreaterThanTwelve() {
         String famName = familyName.replace("*", "44*");
 
-        List<DM56EngineFamilyPacket> parsedPackets = listOf(createDM56(null, 2006, "2006E-MY", null, famName));
+        List<DM56EngineFamilyPacket> parsedPackets = Collections.singletonList(createDM56(null, 2006, "2006E-MY", null, famName));
         when(vehicleInformationModule.reportEngineFamily(any())).thenReturn(parsedPackets);
 
         VehicleInformation vehicleInformation = mock(VehicleInformation.class);
@@ -206,12 +207,11 @@ public class Step06ControllerTest extends AbstractControllerTest {
     public void testAstriskPositionLessThanTwelve() {
         String famName = familyName.replace("A", "*");
 
-        List<DM56EngineFamilyPacket> parsedPackets = listOf(
-                createDM56(null,
-                        2006,
-                        "2006E-MY",
-                        null,
-                        famName));
+        List<DM56EngineFamilyPacket> parsedPackets = Collections.singletonList(createDM56(null,
+        2006,
+        "2006E-MY",
+        null,
+        famName));
         when(vehicleInformationModule.reportEngineFamily(any())).thenReturn(parsedPackets);
 
         VehicleInformation vehicleInformation = mock(VehicleInformation.class);
@@ -251,7 +251,7 @@ public class Step06ControllerTest extends AbstractControllerTest {
     @Test
     @TestDoc(value = @TestItem(verifies = "6.1.6.2.a", description = "Engine model year does not match user input"))
     public void testEngineModelYearDoesntMatch() {
-        List<DM56EngineFamilyPacket> parsedPackets = listOf(createDM56(null, 2006, "2006E-MY", null, familyName));
+        List<DM56EngineFamilyPacket> parsedPackets = Collections.singletonList(createDM56(null, 2006, "2006E-MY", null, familyName));
         when(vehicleInformationModule.reportEngineFamily(any())).thenReturn(parsedPackets);
 
         VehicleInformation vehicleInformation = mock(VehicleInformation.class);
@@ -287,7 +287,7 @@ public class Step06ControllerTest extends AbstractControllerTest {
     public void testFamilyNameLessThan13Characters() {
         String famName = familyName.replace(" OBD*", "");
 
-        List<DM56EngineFamilyPacket> parsedPackets = listOf(createDM56(null, 2006, "2006E-MY", null, famName));
+        List<DM56EngineFamilyPacket> parsedPackets = Collections.singletonList(createDM56(null, 2006, "2006E-MY", null, famName));
         when(vehicleInformationModule.reportEngineFamily(any())).thenReturn(parsedPackets);
 
         VehicleInformation vehicleInformation = mock(VehicleInformation.class);
@@ -337,8 +337,7 @@ public class Step06ControllerTest extends AbstractControllerTest {
         // Remove asterisk from name to test valid null termination
         String famName = familyName.replace('*', Character.MIN_VALUE);
 
-        List<DM56EngineFamilyPacket> parsedPackets = listOf(
-                createDM56(null, 2006, "2006E-MY", null, famName));
+        List<DM56EngineFamilyPacket> parsedPackets = Collections.singletonList(createDM56(null, 2006, "2006E-MY", null, famName));
         when(vehicleInformationModule.reportEngineFamily(any())).thenReturn(parsedPackets);
 
         VehicleInformation vehicleInformation = mock(VehicleInformation.class);
@@ -370,8 +369,7 @@ public class Step06ControllerTest extends AbstractControllerTest {
         // Remove asterisk from name to test valid null termination
         String famName = familyName.replace("*", "4");
 
-        List<DM56EngineFamilyPacket> parsedPackets = listOf(
-                createDM56(null, 2006, "2006E-MY", null, famName));
+        List<DM56EngineFamilyPacket> parsedPackets = Collections.singletonList(createDM56(null, 2006, "2006E-MY", null, famName));
         when(vehicleInformationModule.reportEngineFamily(any())).thenReturn(parsedPackets);
 
         VehicleInformation vehicleInformation = mock(VehicleInformation.class);
@@ -431,7 +429,7 @@ public class Step06ControllerTest extends AbstractControllerTest {
                      + "Not formatted correctly")
 
     public void testModelYearField() {
-        List<DM56EngineFamilyPacket> parsedPackets = listOf(createDM56(null, 2006, "2006V-MY", null, familyName));
+        List<DM56EngineFamilyPacket> parsedPackets = Collections.singletonList(createDM56(null, 2006, "2006V-MY", null, familyName));
         when(vehicleInformationModule.reportEngineFamily(any())).thenReturn(parsedPackets);
 
         VehicleInformation vehicleInformation = mock(VehicleInformation.class);
@@ -496,7 +494,7 @@ public class Step06ControllerTest extends AbstractControllerTest {
     @Test
     @TestDoc(value = @TestItem(verifies = "6.1.6", description = "Happy Path with no errors and one packet"))
     public void testRunHappyPath() {
-        List<DM56EngineFamilyPacket> parsedPackets = listOf(createDM56(null, 2006, "2006E-MY", null, familyName));
+        List<DM56EngineFamilyPacket> parsedPackets = Collections.singletonList(createDM56(null, 2006, "2006E-MY", null, familyName));
         when(vehicleInformationModule.reportEngineFamily(any())).thenReturn(parsedPackets);
 
         VehicleInformation vehicleInformation = mock(VehicleInformation.class);

--- a/src-test/org/etools/j1939_84/controllers/part1/Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Step07ControllerTest.java
@@ -28,7 +28,6 @@ import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response;
 import org.etools.j1939_84.bus.j1939.packets.DM19CalibrationInformationPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM19CalibrationInformationPacket.CalibrationInformation;
-import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
@@ -80,12 +79,6 @@ public class Step07ControllerTest {
         when(packet.getCalibrationInformation()).thenReturn(calInfo);
 
         return packet;
-    }
-
-    private static <T extends ParsedPacket> List<T> listOf(T packet) {
-        List<T> result = new ArrayList<>();
-        result.add(packet);
-        return result;
     }
 
     @Mock

--- a/src-test/org/etools/j1939_84/controllers/part1/Step09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Step09ControllerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,8 +56,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class Step09ControllerTest extends AbstractControllerTest {
 
     /*
-     * All values must be checked prior to mocking so that we are not
-     * creating unnecessary mocks.
+     * All values must be checked prior to mocking so that we are not creating
+     * unnecessary mocks.
      */
     private static ComponentIdentificationPacket createComponentIdPacket(Integer sourceAddress,
             String make,
@@ -155,9 +156,9 @@ public class Step09ControllerTest extends AbstractControllerTest {
     /*
      * 6.1.9.1 ACTIONS:
      *
-     * a. Destination Specific (DS) Component ID request (PGN 59904) for PGN 65259
-     * (SPNs 586, 587, and 588) to each OBD ECU.
-     * b. Display each positive return in the log.
+     * a. Destination Specific (DS) Component ID request (PGN 59904) for PGN
+     * 65259 (SPNs 586, 587, and 588) to each OBD ECU. b. Display each positive
+     * return in the log.
      */
 
     @Before
@@ -223,7 +224,7 @@ public class Step09ControllerTest extends AbstractControllerTest {
         when(dataRepository.getObdModuleAddresses()).thenReturn(moduleAddressFunction.keySet());
 
         when(vehicleInformationModule.reportComponentIdentification(any(), eq(0)))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         List<OBDModuleInformation> obdModuleInformations = new ArrayList<>();
         for (Entry<Integer, Integer> address : moduleAddressFunction.entrySet()) {
@@ -279,13 +280,14 @@ public class Step09ControllerTest extends AbstractControllerTest {
         when(dataRepository.getObdModuleAddresses()).thenReturn(moduleAddressFunction.keySet());
 
         when(vehicleInformationModule.reportComponentIdentification(any()))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         when(vehicleInformationModule.reportComponentIdentification(any(), eq(0)))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         List<OBDModuleInformation> obdModuleInformations = new ArrayList<>();
-        // OBDModuleInformation obdModuleInfomation = new OBDModuleInformation(0);
+        // OBDModuleInformation obdModuleInfomation = new
+        // OBDModuleInformation(0);
         for (Entry<Integer, Integer> address : moduleAddressFunction.entrySet()) {
             obdModuleInformations
                     .add(createOBDModuleInformation(address
@@ -339,10 +341,10 @@ public class Step09ControllerTest extends AbstractControllerTest {
         when(dataRepository.getObdModuleAddresses()).thenReturn(moduleAddressFunction.keySet());
 
         when(vehicleInformationModule.reportComponentIdentification(any()))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         when(vehicleInformationModule.reportComponentIdentification(any(), eq(0)))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         List<OBDModuleInformation> obdModuleInformations = new ArrayList<>();
         for (Entry<Integer, Integer> address : moduleAddressFunction.entrySet()) {
@@ -388,13 +390,14 @@ public class Step09ControllerTest extends AbstractControllerTest {
         when(dataRepository.getObdModuleAddresses()).thenReturn(moduleAddressFunction.keySet());
 
         when(vehicleInformationModule.reportComponentIdentification(any()))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         when(vehicleInformationModule.reportComponentIdentification(any(), eq(0)))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         List<OBDModuleInformation> obdModuleInformations = new ArrayList<>();
-        // OBDModuleInformation obdModuleInfomation = new OBDModuleInformation(0);
+        // OBDModuleInformation obdModuleInfomation = new
+        // OBDModuleInformation(0);
         for (Entry<Integer, Integer> address : moduleAddressFunction.entrySet()) {
             obdModuleInformations
                     .add(createOBDModuleInformation(address
@@ -448,13 +451,14 @@ public class Step09ControllerTest extends AbstractControllerTest {
         when(dataRepository.getObdModuleAddresses()).thenReturn(moduleAddressFunction.keySet());
 
         when(vehicleInformationModule.reportComponentIdentification(any()))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         when(vehicleInformationModule.reportComponentIdentification(any(), eq(0)))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         List<OBDModuleInformation> obdModuleInformations = new ArrayList<>();
-        // OBDModuleInformation obdModuleInfomation = new OBDModuleInformation(0);
+        // OBDModuleInformation obdModuleInfomation = new
+        // OBDModuleInformation(0);
         for (Entry<Integer, Integer> address : moduleAddressFunction.entrySet()) {
             obdModuleInformations
                     .add(createOBDModuleInformation(address
@@ -508,13 +512,14 @@ public class Step09ControllerTest extends AbstractControllerTest {
         when(dataRepository.getObdModuleAddresses()).thenReturn(moduleAddressFunction.keySet());
 
         when(vehicleInformationModule.reportComponentIdentification(any()))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         when(vehicleInformationModule.reportComponentIdentification(any(), eq(0)))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         List<OBDModuleInformation> obdModuleInformations = new ArrayList<>();
-        // OBDModuleInformation obdModuleInfomation = new OBDModuleInformation(0);
+        // OBDModuleInformation obdModuleInfomation = new
+        // OBDModuleInformation(0);
         for (Entry<Integer, Integer> address : moduleAddressFunction.entrySet()) {
             obdModuleInformations
                     .add(createOBDModuleInformation(address
@@ -569,13 +574,14 @@ public class Step09ControllerTest extends AbstractControllerTest {
         when(dataRepository.getObdModuleAddresses()).thenReturn(moduleAddressFunction.keySet());
 
         when(vehicleInformationModule.reportComponentIdentification(any()))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         when(vehicleInformationModule.reportComponentIdentification(any(), eq(0)))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         List<OBDModuleInformation> obdModuleInformations = new ArrayList<>();
-        // OBDModuleInformation obdModuleInfomation = new OBDModuleInformation(0);
+        // OBDModuleInformation obdModuleInfomation = new
+        // OBDModuleInformation(0);
         for (Entry<Integer, Integer> address : moduleAddressFunction.entrySet()) {
             obdModuleInformations
                     .add(createOBDModuleInformation(address
@@ -629,13 +635,14 @@ public class Step09ControllerTest extends AbstractControllerTest {
         when(dataRepository.getObdModuleAddresses()).thenReturn(moduleAddressFunction.keySet());
 
         when(vehicleInformationModule.reportComponentIdentification(any()))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         when(vehicleInformationModule.reportComponentIdentification(any(), eq(0)))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         List<OBDModuleInformation> obdModuleInformations = new ArrayList<>();
-        // OBDModuleInformation obdModuleInfomation = new OBDModuleInformation(0);
+        // OBDModuleInformation obdModuleInfomation = new
+        // OBDModuleInformation(0);
         for (Entry<Integer, Integer> address : moduleAddressFunction.entrySet()) {
             obdModuleInformations
                     .add(createOBDModuleInformation(address
@@ -702,9 +709,9 @@ public class Step09ControllerTest extends AbstractControllerTest {
                 .thenReturn(packetList);
 
         when(vehicleInformationModule.reportComponentIdentification(any(), eq(0)))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
         when(vehicleInformationModule.reportComponentIdentification(any(), eq(1)))
-                .thenReturn(listOf(packet1));
+                .thenReturn(Collections.singletonList(packet1));
 
         List<OBDModuleInformation> obdModuleInformations = new ArrayList<>();
         for (Entry<Integer, Integer> address : moduleAddressFunction.entrySet()) {
@@ -759,10 +766,10 @@ public class Step09ControllerTest extends AbstractControllerTest {
         when(dataRepository.getObdModuleAddresses()).thenReturn(moduleAddressFunction.keySet());
 
         when(vehicleInformationModule.reportComponentIdentification(any()))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         when(vehicleInformationModule.reportComponentIdentification(any(), eq(0)))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         // Return and empty list of modules
         List<OBDModuleInformation> obdModuleInformations = new ArrayList<>();
@@ -822,12 +829,13 @@ public class Step09ControllerTest extends AbstractControllerTest {
         when(dataRepository.getObdModuleAddresses()).thenReturn(moduleAddressFunction.keySet());
 
         when(vehicleInformationModule.reportComponentIdentification(any(), eq(0)))
-                .thenReturn(listOf(null));
+                .thenReturn(Collections.emptyList());
         when(vehicleInformationModule.reportComponentIdentification(any()))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         List<OBDModuleInformation> obdModuleInformations = new ArrayList<>();
-        // OBDModuleInformation obdModuleInfomation = new OBDModuleInformation(0);
+        // OBDModuleInformation obdModuleInfomation = new
+        // OBDModuleInformation(0);
         for (Entry<Integer, Integer> address : moduleAddressFunction.entrySet()) {
             obdModuleInformations
                     .add(createOBDModuleInformation(address
@@ -889,13 +897,14 @@ public class Step09ControllerTest extends AbstractControllerTest {
         when(dataRepository.getObdModuleAddresses()).thenReturn(moduleAddressFunction.keySet());
 
         when(vehicleInformationModule.reportComponentIdentification(any()))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         when(vehicleInformationModule.reportComponentIdentification(any(), eq(0)))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         List<OBDModuleInformation> obdModuleInformations = new ArrayList<>();
-        // OBDModuleInformation obdModuleInfomation = new OBDModuleInformation(0);
+        // OBDModuleInformation obdModuleInfomation = new
+        // OBDModuleInformation(0);
         for (Entry<Integer, Integer> address : moduleAddressFunction.entrySet()) {
             obdModuleInformations
                     .add(createOBDModuleInformation(address
@@ -949,10 +958,10 @@ public class Step09ControllerTest extends AbstractControllerTest {
         when(dataRepository.getObdModuleAddresses()).thenReturn(moduleAddressFunction.keySet());
 
         when(vehicleInformationModule.reportComponentIdentification(any()))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         when(vehicleInformationModule.reportComponentIdentification(any(), eq(0)))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         List<OBDModuleInformation> obdModuleInformations = new ArrayList<>();
         for (Entry<Integer, Integer> address : moduleAddressFunction.entrySet()) {
@@ -1007,10 +1016,10 @@ public class Step09ControllerTest extends AbstractControllerTest {
         when(dataRepository.getObdModuleAddresses()).thenReturn(moduleAddressFunction.keySet());
 
         when(vehicleInformationModule.reportComponentIdentification(any()))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         when(vehicleInformationModule.reportComponentIdentification(any(), eq(0)))
-                .thenReturn(listOf(packet));
+                .thenReturn(Collections.singletonList(packet));
 
         List<OBDModuleInformation> obdModuleInformations = new ArrayList<>();
         for (Entry<Integer, Integer> address : moduleAddressFunction.entrySet()) {

--- a/src-test/org/etools/j1939_84/controllers/part1/Step11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Step11ControllerTest.java
@@ -181,15 +181,15 @@ public class Step11ControllerTest extends AbstractControllerTest {
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet4), Collections.emptyList()));
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet5), Collections.emptyList()));
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), Collections.singletonList(packet3)));
 
         runTest();
         verify(dataRepository).getObdModuleAddresses();
@@ -271,19 +271,19 @@ public class Step11ControllerTest extends AbstractControllerTest {
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet4), Collections.emptyList()));
         globalPackets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet5), Collections.emptyList()));
         globalPackets.add(packet5);
 
         AcknowledgmentPacket packet2 = mock(AcknowledgmentPacket.class);
 
         DM21DiagnosticReadinessPacket packet3 = createDM21Packet(21, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, listOf(packet3), Collections.singletonList(packet2)));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet3), Collections.singletonList(packet2)));
 
         runTest();
         verify(dataRepository).getObdModuleAddresses();
@@ -338,23 +338,23 @@ public class Step11ControllerTest extends AbstractControllerTest {
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet4), Collections.emptyList()));
         globalPackets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet5), Collections.emptyList()));
         globalPackets.add(packet5);
 
         AcknowledgmentPacket packet2 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(9)))
-                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet2)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), Collections.singletonList(packet2)));
         when(packet2.getResponse()).thenReturn(Response.NACK);
         when(packet2.getSourceAddress()).thenReturn(9);
 
         DM21DiagnosticReadinessPacket packet3 = createDM21Packet(21, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, listOf(packet3), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet3), Collections.emptyList()));
 
         runTest();
         verify(dataRepository).getObdModuleAddresses();
@@ -410,23 +410,23 @@ public class Step11ControllerTest extends AbstractControllerTest {
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet4), Collections.emptyList()));
         globalPackets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet5), Collections.emptyList()));
         globalPackets.add(packet5);
 
         AcknowledgmentPacket packet2 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(9)))
-                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet2)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), Collections.singletonList(packet2)));
         when(packet2.getResponse()).thenReturn(Response.NACK);
         when(packet2.getSourceAddress()).thenReturn(16);
 
         DM21DiagnosticReadinessPacket packet3 = createDM21Packet(21, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, listOf(packet3), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet3), Collections.emptyList()));
 
         runTest();
         verify(dataRepository).getObdModuleAddresses();
@@ -494,17 +494,17 @@ public class Step11ControllerTest extends AbstractControllerTest {
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet4), Collections.emptyList()));
         packets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), Collections.singletonList(packet3)));
 
         runTest();
         verify(dataRepository).getObdModuleAddresses();
@@ -548,18 +548,18 @@ public class Step11ControllerTest extends AbstractControllerTest {
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet4), Collections.emptyList()));
 
         packets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 15.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), Collections.singletonList(packet3)));
 
         runTest();
 
@@ -623,17 +623,17 @@ public class Step11ControllerTest extends AbstractControllerTest {
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet4), Collections.emptyList()));
         packets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 10.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), Collections.singletonList(packet3)));
 
         runTest();
 
@@ -696,17 +696,17 @@ public class Step11ControllerTest extends AbstractControllerTest {
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet4), Collections.emptyList()));
         packets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 15.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), Collections.singletonList(packet3)));
 
         runTest();
 
@@ -769,17 +769,17 @@ public class Step11ControllerTest extends AbstractControllerTest {
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet4), Collections.emptyList()));
         packets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 10.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), Collections.singletonList(packet3)));
 
         runTest();
 
@@ -842,17 +842,17 @@ public class Step11ControllerTest extends AbstractControllerTest {
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet4), Collections.emptyList()));
         packets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 0.0, 20.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), Collections.singletonList(packet3)));
 
         runTest();
         verify(dataRepository).getObdModuleAddresses();
@@ -916,17 +916,17 @@ public class Step11ControllerTest extends AbstractControllerTest {
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 25.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet4), Collections.emptyList()));
         packets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         createDM21Packet(21, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         runTest();

--- a/src-test/org/etools/j1939_84/controllers/part1/Step11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Step11ControllerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -21,7 +22,6 @@ import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response;
 import org.etools.j1939_84.bus.j1939.packets.DM21DiagnosticReadinessPacket;
-import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.Outcome;
@@ -52,8 +52,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class Step11ControllerTest extends AbstractControllerTest {
 
     /*
-     * All values must be checked prior to mocking so that we are not
-     * creating unnecessary mocks.
+     * All values must be checked prior to mocking so that we are not creating
+     * unnecessary mocks.
      */
     private static DM21DiagnosticReadinessPacket createDM21Packet(Integer sourceAddress,
             Double kmSinceDtcCleared,
@@ -171,24 +171,25 @@ public class Step11ControllerTest extends AbstractControllerTest {
         };
         when(dataRepository.getObdModuleAddresses()).thenReturn(obdAddressSet);
 
-        List<ParsedPacket> emptyPackets = new ArrayList<>();
-        // return packets when Global DM21 request (PGN 59904) for PGN 49408 (SPNs 3069,
+        List<DM21DiagnosticReadinessPacket> emptyPackets = new ArrayList<>();
+        // return packets when Global DM21 request (PGN 59904) for PGN 49408
+        // (SPNs 3069,
         // 3294-3296)).
         when(diagnosticReadinessModule.requestDM21Packets(any(), eq(true)))
-                .thenReturn(new RequestResult<>(false, emptyPackets));
+                .thenReturn(new RequestResult<>(false, emptyPackets, Collections.emptyList()));
         // return the set of OBD module addresses when requested
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4)));
+                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5)));
+                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet3)));
 
         runTest();
         verify(dataRepository).getObdModuleAddresses();
@@ -260,29 +261,29 @@ public class Step11ControllerTest extends AbstractControllerTest {
         };
         when(dataRepository.getObdModuleAddresses()).thenReturn(obdAddressSet);
 
-        List<ParsedPacket> globalPackets = new ArrayList<>();
-        // return packets when Global DM21 request (PGN 59904) for PGN 49408 (SPNs 3069,
+        List<DM21DiagnosticReadinessPacket> globalPackets = new ArrayList<>();
+        // return packets when Global DM21 request (PGN 59904) for PGN 49408
+        // (SPNs 3069,
         // 3294-3296)).
         when(diagnosticReadinessModule.requestDM21Packets(any(), eq(true)))
-                .thenReturn(new RequestResult<>(false, globalPackets));
+                .thenReturn(new RequestResult<>(false, globalPackets, Collections.emptyList()));
         // return the set of OBD module addresses when requested
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4)));
+                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
         globalPackets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5)));
+                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
         globalPackets.add(packet5);
 
         AcknowledgmentPacket packet2 = mock(AcknowledgmentPacket.class);
-        globalPackets.add(packet2);
 
         DM21DiagnosticReadinessPacket packet3 = createDM21Packet(21, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, listOf(packet3), Collections.singletonList(packet2)));
 
         runTest();
         verify(dataRepository).getObdModuleAddresses();
@@ -325,34 +326,35 @@ public class Step11ControllerTest extends AbstractControllerTest {
         };
         when(dataRepository.getObdModuleAddresses()).thenReturn(obdAddressSet);
 
-        List<ParsedPacket> globalPackets = new ArrayList<>();
-        // return packets when Global DM21 request (PGN 59904) for PGN 49408 (SPNs 3069,
+        List<DM21DiagnosticReadinessPacket> globalPackets = new ArrayList<>();
+        // return packets when Global DM21 request (PGN 59904) for PGN 49408
+        // (SPNs 3069,
         // 3294-3296)).
         when(diagnosticReadinessModule.requestDM21Packets(any(), eq(true)))
-                .thenReturn(new RequestResult<>(false, globalPackets));
+                .thenReturn(new RequestResult<>(false, globalPackets, Collections.emptyList()));
         // return the set of OBD module addresses when requested
         DM21DiagnosticReadinessPacket packet1 = createDM21Packet(9, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         globalPackets.add(packet1);
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4)));
+                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
         globalPackets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5)));
+                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
         globalPackets.add(packet5);
 
         AcknowledgmentPacket packet2 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(9)))
-                .thenReturn(new RequestResult<>(false, listOf(packet2)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet2)));
         when(packet2.getResponse()).thenReturn(Response.NACK);
         when(packet2.getSourceAddress()).thenReturn(9);
 
         DM21DiagnosticReadinessPacket packet3 = createDM21Packet(21, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, listOf(packet3), Collections.emptyList()));
 
         runTest();
         verify(dataRepository).getObdModuleAddresses();
@@ -396,34 +398,35 @@ public class Step11ControllerTest extends AbstractControllerTest {
         };
         when(dataRepository.getObdModuleAddresses()).thenReturn(obdAddressSet);
 
-        List<ParsedPacket> globalPackets = new ArrayList<>();
-        // return packets when Global DM21 request (PGN 59904) for PGN 49408 (SPNs 3069,
+        List<DM21DiagnosticReadinessPacket> globalPackets = new ArrayList<>();
+        // return packets when Global DM21 request (PGN 59904) for PGN 49408
+        // (SPNs 3069,
         // 3294-3296)).
         when(diagnosticReadinessModule.requestDM21Packets(any(), eq(true)))
-                .thenReturn(new RequestResult<>(false, globalPackets));
+                .thenReturn(new RequestResult<>(false, globalPackets, Collections.emptyList()));
         // return the set of OBD module addresses when requested
         DM21DiagnosticReadinessPacket packet1 = createDM21Packet(9, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         globalPackets.add(packet1);
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4)));
+                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
         globalPackets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5)));
+                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
         globalPackets.add(packet5);
 
         AcknowledgmentPacket packet2 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(9)))
-                .thenReturn(new RequestResult<>(false, listOf(packet2)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet2)));
         when(packet2.getResponse()).thenReturn(Response.NACK);
         when(packet2.getSourceAddress()).thenReturn(16);
 
         DM21DiagnosticReadinessPacket packet3 = createDM21Packet(21, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, listOf(packet3), Collections.emptyList()));
 
         runTest();
         verify(dataRepository).getObdModuleAddresses();
@@ -481,26 +484,27 @@ public class Step11ControllerTest extends AbstractControllerTest {
         };
         when(dataRepository.getObdModuleAddresses()).thenReturn(obdAddressSet);
 
-        List<ParsedPacket> packets = new ArrayList<>();
-        // return packets when Global DM21 request (PGN 59904) for PGN 49408 (SPNs 3069,
+        List<DM21DiagnosticReadinessPacket> packets = new ArrayList<>();
+        // return packets when Global DM21 request (PGN 59904) for PGN 49408
+        // (SPNs 3069,
         // 3294-3296)).
         when(diagnosticReadinessModule.requestDM21Packets(any(), eq(true)))
-                .thenReturn(new RequestResult<>(false, packets));
+                .thenReturn(new RequestResult<>(false, packets, Collections.emptyList()));
         // return the set of OBD module addresses when requested
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4)));
+                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
         packets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5)));
+                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet3)));
 
         runTest();
         verify(dataRepository).getObdModuleAddresses();
@@ -532,29 +536,30 @@ public class Step11ControllerTest extends AbstractControllerTest {
             }
         };
         when(dataRepository.getObdModuleAddresses()).thenReturn(obdAddressSet);
-        List<ParsedPacket> packets = new ArrayList<>();
+        List<DM21DiagnosticReadinessPacket> packets = new ArrayList<>();
 
-        // return packets when Global DM21 request (PGN 59904) for PGN 49408 (SPNs 3069,
+        // return packets when Global DM21 request (PGN 59904) for PGN 49408
+        // (SPNs 3069,
         // 3294-3296)).
 
         when(diagnosticReadinessModule.requestDM21Packets(any(), eq(true)))
-                .thenReturn(new RequestResult<>(false, packets));
+                .thenReturn(new RequestResult<>(false, packets, Collections.emptyList()));
         // return the set of OBD module addresses when requested
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4)));
+                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
 
         packets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 15.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5)));
+                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet3)));
 
         runTest();
 
@@ -608,26 +613,27 @@ public class Step11ControllerTest extends AbstractControllerTest {
         };
         when(dataRepository.getObdModuleAddresses()).thenReturn(obdAddressSet);
 
-        List<ParsedPacket> packets = new ArrayList<>();
-        // return packets when Global DM21 request (PGN 59904) for PGN 49408 (SPNs 3069,
+        List<DM21DiagnosticReadinessPacket> packets = new ArrayList<>();
+        // return packets when Global DM21 request (PGN 59904) for PGN 49408
+        // (SPNs 3069,
         // 3294-3296)).
         when(diagnosticReadinessModule.requestDM21Packets(any(), eq(true)))
-                .thenReturn(new RequestResult<>(false, packets));
+                .thenReturn(new RequestResult<>(false, packets, Collections.emptyList()));
         // return the set of OBD module addresses when requested
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4)));
+                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
         packets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 10.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5)));
+                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet3)));
 
         runTest();
 
@@ -681,25 +687,26 @@ public class Step11ControllerTest extends AbstractControllerTest {
         // return the set of OBD module addresses when requested
         when(dataRepository.getObdModuleAddresses()).thenReturn(obdAddressSet);
 
-        List<ParsedPacket> packets = new ArrayList<>();
-        // return packets when Global DM21 request (PGN 59904) for PGN 49408 (SPNs 3069,
+        List<DM21DiagnosticReadinessPacket> packets = new ArrayList<>();
+        // return packets when Global DM21 request (PGN 59904) for PGN 49408
+        // (SPNs 3069,
         // 3294-3296)).
         when(diagnosticReadinessModule.requestDM21Packets(any(), eq(true)))
-                .thenReturn(new RequestResult<>(false, packets));
+                .thenReturn(new RequestResult<>(false, packets, Collections.emptyList()));
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4)));
+                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
         packets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 15.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5)));
+                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet3)));
 
         runTest();
 
@@ -753,25 +760,26 @@ public class Step11ControllerTest extends AbstractControllerTest {
         };
         when(dataRepository.getObdModuleAddresses()).thenReturn(obdAddressSet);
 
-        List<ParsedPacket> packets = new ArrayList<>();
-        // return packets when Global DM21 request (PGN 59904) for PGN 49408 (SPNs 3069,
+        List<DM21DiagnosticReadinessPacket> packets = new ArrayList<>();
+        // return packets when Global DM21 request (PGN 59904) for PGN 49408
+        // (SPNs 3069,
         // 3294-3296)).
         when(diagnosticReadinessModule.requestDM21Packets(any(), eq(true)))
-                .thenReturn(new RequestResult<>(false, packets));
+                .thenReturn(new RequestResult<>(false, packets, Collections.emptyList()));
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4)));
+                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
         packets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 10.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5)));
+                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet3)));
 
         runTest();
 
@@ -825,25 +833,26 @@ public class Step11ControllerTest extends AbstractControllerTest {
         // return the set of OBD module addresses when requested
         when(dataRepository.getObdModuleAddresses()).thenReturn(obdAddressSet);
 
-        List<ParsedPacket> packets = new ArrayList<>();
-        // return packets when Global DM21 request (PGN 59904) for PGN 49408 (SPNs 3069,
+        List<DM21DiagnosticReadinessPacket> packets = new ArrayList<>();
+        // return packets when Global DM21 request (PGN 59904) for PGN 49408
+        // (SPNs 3069,
         // 3294-3296)).
         when(diagnosticReadinessModule.requestDM21Packets(any(), eq(true)))
-                .thenReturn(new RequestResult<>(false, packets));
+                .thenReturn(new RequestResult<>(false, packets, Collections.emptyList()));
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4)));
+                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
         packets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 0.0, 20.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5)));
+                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, listOf(packet3)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet3)));
 
         runTest();
         verify(dataRepository).getObdModuleAddresses();
@@ -897,26 +906,27 @@ public class Step11ControllerTest extends AbstractControllerTest {
         };
         when(dataRepository.getObdModuleAddresses()).thenReturn(obdAddressSet);
 
-        List<ParsedPacket> packets = new ArrayList<>();
-        // return packets when Global DM21 request (PGN 59904) for PGN 49408 (SPNs 3069,
+        List<DM21DiagnosticReadinessPacket> packets = new ArrayList<>();
+        // return packets when Global DM21 request (PGN 59904) for PGN 49408
+        // (SPNs 3069,
         // 3294-3296)).
         when(diagnosticReadinessModule.requestDM21Packets(any(), eq(true)))
-                .thenReturn(new RequestResult<>(false, packets));
+                .thenReturn(new RequestResult<>(false, packets, Collections.emptyList()));
         // return the set of OBD module addresses when requested
 
         DM21DiagnosticReadinessPacket packet4 = createDM21Packet(0, 0.0, 0.0, 0.0, 0.0, 0.0, 25.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4)));
+                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
         packets.add(packet4);
 
         DM21DiagnosticReadinessPacket packet5 = createDM21Packet(17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(17)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5)));
+                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         createDM21Packet(21, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         when(diagnosticReadinessModule.getDM21Packets(any(), eq(true), eq(21)))
-                .thenReturn(new RequestResult<>(false, listOf(packet5)));
+                .thenReturn(new RequestResult<>(false, listOf(packet5), Collections.emptyList()));
         packets.add(packet5);
 
         runTest();

--- a/src-test/org/etools/j1939_84/controllers/part1/Step12ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Step12ControllerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
 
@@ -579,7 +580,7 @@ public class Step12ControllerTest extends AbstractControllerTest {
 
         // FIXME - I shouldn't have to mock this - .reportDuplicates needs to be
         // corrected.
-        when(tableA7Validator.hasDuplicates(scaledTestsResults)).thenReturn(listOf(scaledTestResult));
+        when(tableA7Validator.hasDuplicates(scaledTestsResults)).thenReturn(Collections.singletonList(scaledTestResult));
 
         List<DM30ScaledTestResultsPacket> dm30Packets = new ArrayList<>();
         DM30ScaledTestResultsPacket dm30Packet = mock(DM30ScaledTestResultsPacket.class);

--- a/src-test/org/etools/j1939_84/controllers/part1/Step16ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Step16ControllerTest.java
@@ -133,7 +133,7 @@ public class Step16ControllerTest extends AbstractControllerTest {
     public void testDTCsNotEmpty() {
         DM2PreviouslyActiveDTC packet1 = mock(DM2PreviouslyActiveDTC.class);
         DiagnosticTroubleCode Dtc1 = mock(DiagnosticTroubleCode.class);
-        when(packet1.getDtcs()).thenReturn(listOf(Dtc1));
+        when(packet1.getDtcs()).thenReturn(Collections.singletonList(Dtc1));
         when(packet1.getSourceAddress()).thenReturn(0);
         when(packet1.getMalfunctionIndicatorLampStatus()).thenReturn(LampStatus.OFF);
 
@@ -151,13 +151,13 @@ public class Step16ControllerTest extends AbstractControllerTest {
         packet2Dtc.add(Dtc2);
         when(packet2.getSourceAddress()).thenReturn(0);
         when(dtcModule.requestDM2(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet2), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet2), Collections.emptyList()));
 
         // add ACK/NACK packets to the listing for complete reality testing
         AcknowledgmentPacket packet4 = mock(AcknowledgmentPacket.class);
         when(packet4.getSourceAddress()).thenReturn(3);
         when(dtcModule.requestDM2(any(), eq(true), eq(3)))
-                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet4)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), Collections.singletonList(packet4)));
 
         // Return the modules address so that we can do the destination specific
         // calls
@@ -334,14 +334,14 @@ public class Step16ControllerTest extends AbstractControllerTest {
         DM2PreviouslyActiveDTC packet2 = mock(DM2PreviouslyActiveDTC.class);
         destinationSpecificPackets.add(packet2);
         when(dtcModule.requestDM2(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet2), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet2), Collections.emptyList()));
 
         // add ACK/NACK packets to the listing for complete reality testing
         AcknowledgmentPacket packet4 = mock(AcknowledgmentPacket.class);
         destinationSpecificPackets.add(packet4);
         when(packet4.getSourceAddress()).thenReturn(3);
         when(dtcModule.requestDM2(any(), eq(true), eq(3)))
-                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet4)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), Collections.singletonList(packet4)));
 
         // Return the modules address so that we can do the destination specific
         // calls
@@ -405,14 +405,14 @@ public class Step16ControllerTest extends AbstractControllerTest {
         DM2PreviouslyActiveDTC packet2 = mock(DM2PreviouslyActiveDTC.class);
         when(packet2.getSourceAddress()).thenReturn(0);
         when(dtcModule.requestDM2(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet2), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet2), Collections.emptyList()));
 
         // add ACK/NACK packets to the listing for complete reality testing
         AcknowledgmentPacket packet4 = mock(AcknowledgmentPacket.class);
         when(packet4.getSourceAddress()).thenReturn(3);
 
         when(dtcModule.requestDM2(any(), eq(true), eq(3)))
-                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet4)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), Collections.singletonList(packet4)));
 
         // Return the modules address so that we can do the destination specific
         // calls
@@ -528,13 +528,13 @@ public class Step16ControllerTest extends AbstractControllerTest {
         DM2PreviouslyActiveDTC packet2 = mock(DM2PreviouslyActiveDTC.class);
         when(packet2.getSourceAddress()).thenReturn(0);
         when(dtcModule.requestDM2(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet2), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet2), Collections.emptyList()));
 
         // add ACK/NACK packets to the listing for complete reality testing
         DM2PreviouslyActiveDTC packet4 = mock(DM2PreviouslyActiveDTC.class);
         when(packet4.getSourceAddress()).thenReturn(3);
         when(dtcModule.requestDM2(any(), eq(true), eq(3)))
-                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet4), Collections.emptyList()));
 
         // Return the modules address so that we can do the destination specific
         // calls
@@ -599,13 +599,13 @@ public class Step16ControllerTest extends AbstractControllerTest {
         DM2PreviouslyActiveDTC packet2 = mock(DM2PreviouslyActiveDTC.class);
         when(packet2.getSourceAddress()).thenReturn(0);
         when(dtcModule.requestDM2(any(), eq(true), eq(0)))
-                .thenReturn(new RequestResult<>(false, listOf(packet2), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet2), Collections.emptyList()));
 
         // add ACK/NACK packets to the listing for complete reality testing
         AcknowledgmentPacket packet4 = mock(AcknowledgmentPacket.class);
         when(packet4.getSourceAddress()).thenReturn(3);
         when(dtcModule.requestDM2(any(), eq(true), eq(3)))
-                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet4)));
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), Collections.singletonList(packet4)));
 
         // Return the modules address so that we can do the destination specific
         // calls

--- a/src-test/org/etools/j1939_84/controllers/part1/Step16ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Step16ControllerTest.java
@@ -131,9 +131,7 @@ public class Step16ControllerTest extends AbstractControllerTest {
     @Test
     @TestDoc(@TestItem(verifies = "6.1.16.2.a"))
     public void testDTCsNotEmpty() {
-        List<ParsedPacket> globalPackets = new ArrayList<>();
         DM2PreviouslyActiveDTC packet1 = mock(DM2PreviouslyActiveDTC.class);
-        globalPackets.add(packet1);
         DiagnosticTroubleCode Dtc1 = mock(DiagnosticTroubleCode.class);
         when(packet1.getDtcs()).thenReturn(listOf(Dtc1));
         when(packet1.getSourceAddress()).thenReturn(0);
@@ -141,9 +139,9 @@ public class Step16ControllerTest extends AbstractControllerTest {
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(packet3.getSourceAddress()).thenReturn(3);
-        globalPackets.add(packet3);
 
-        when(dtcModule.requestDM2(any(), eq(true))).thenReturn(new RequestResult<>(false, globalPackets));
+        when(dtcModule.requestDM2(any(), eq(true))).thenReturn(
+                new RequestResult<>(false, Collections.singletonList(packet1), Collections.singletonList(packet3)));
 
         // Set up the destination specific packets we will be returning when
         // requested
@@ -152,12 +150,14 @@ public class Step16ControllerTest extends AbstractControllerTest {
         DiagnosticTroubleCode Dtc2 = mock(DiagnosticTroubleCode.class);
         packet2Dtc.add(Dtc2);
         when(packet2.getSourceAddress()).thenReturn(0);
-        when(dtcModule.requestDM2(any(), eq(true), eq(0))).thenReturn(new RequestResult<>(false, listOf(packet2)));
+        when(dtcModule.requestDM2(any(), eq(true), eq(0)))
+                .thenReturn(new RequestResult<>(false, listOf(packet2), Collections.emptyList()));
 
         // add ACK/NACK packets to the listing for complete reality testing
         AcknowledgmentPacket packet4 = mock(AcknowledgmentPacket.class);
         when(packet4.getSourceAddress()).thenReturn(3);
-        when(dtcModule.requestDM2(any(), eq(true), eq(3))).thenReturn(new RequestResult<>(false, listOf(packet4)));
+        when(dtcModule.requestDM2(any(), eq(true), eq(3)))
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet4)));
 
         // Return the modules address so that we can do the destination specific
         // calls
@@ -208,17 +208,15 @@ public class Step16ControllerTest extends AbstractControllerTest {
     @Test
     @TestDoc({ @TestItem(verifies = "6.1.16.2.a,b") })
     public void testMILNotSupported() {
-
-        List<ParsedPacket> globalPackets = new ArrayList<>();
         DM2PreviouslyActiveDTC packet1 = mock(DM2PreviouslyActiveDTC.class);
-        globalPackets.add(packet1);
         when(packet1.getSourceAddress()).thenReturn(0);
         when(packet1.getMalfunctionIndicatorLampStatus()).thenReturn(LampStatus.OTHER);
-        when(dtcModule.requestDM2(any(), eq(true))).thenReturn(new RequestResult<>(false, globalPackets));
+        when(dtcModule.requestDM2(any(), eq(true)))
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet1), Collections.emptyList()));
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(packet3.getResponse()).thenReturn(Response.NACK);
-        globalPackets.add(packet3);
+        // what was this for? globalPackets.add(packet3);
 
         // Return the modules address so that we can do the destination specific
         // calls
@@ -263,9 +261,7 @@ public class Step16ControllerTest extends AbstractControllerTest {
     @TestDoc(@TestItem(verifies = "6.1.16.2.a"))
     public void testMILOff() {
 
-        List<ParsedPacket> globalPackets = new ArrayList<>();
         DM2PreviouslyActiveDTC packet1 = mock(DM2PreviouslyActiveDTC.class);
-        globalPackets.add(packet1);
         when(packet1.getSourceAddress()).thenReturn(0);
         when(packet1.getMalfunctionIndicatorLampStatus()).thenReturn(LampStatus.OFF);
 
@@ -273,9 +269,9 @@ public class Step16ControllerTest extends AbstractControllerTest {
         when(packet3.getResponse()).thenReturn(Response.NACK);
         // because this is a NACK, the SA will not be requested.
         // when(packet3.getSourceAddress()).thenReturn(3);
-        globalPackets.add(packet3);
 
-        when(dtcModule.requestDM2(any(), eq(true))).thenReturn(new RequestResult<>(false, globalPackets));
+        when(dtcModule.requestDM2(any(), eq(true))).thenReturn(
+                new RequestResult<>(false, Collections.singletonList(packet1), Collections.singletonList(packet3)));
 
         // Set up the destination specific packets we will be returning when
         // requested
@@ -321,30 +317,31 @@ public class Step16ControllerTest extends AbstractControllerTest {
     @Test
     @TestDoc({ @TestItem(verifies = "6.1.16.2.a,b") })
     public void testMILStatusNotOFF() {
-        List<ParsedPacket> globalPackets = new ArrayList<>();
         DM2PreviouslyActiveDTC packet1 = mock(DM2PreviouslyActiveDTC.class);
-        globalPackets.add(packet1);
         when(packet1.getDtcs()).thenReturn(Collections.emptyList());
         when(packet1.getSourceAddress()).thenReturn(0);
         when(packet1.getMalfunctionIndicatorLampStatus()).thenReturn(LampStatus.ON);
-        when(dtcModule.requestDM2(any(), eq(true))).thenReturn(new RequestResult<>(false, globalPackets));
+        when(dtcModule.requestDM2(any(), eq(true)))
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet1), Collections.emptyList()));
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(packet3.getResponse()).thenReturn(Response.NACK);
-        globalPackets.add(packet3);
+        // FIXME What is this? globalPackets.add(packet3);
 
         // Set up the destination specific packets we will be returning when
         // requested
         List<ParsedPacket> destinationSpecificPackets = new ArrayList<>();
         DM2PreviouslyActiveDTC packet2 = mock(DM2PreviouslyActiveDTC.class);
         destinationSpecificPackets.add(packet2);
-        when(dtcModule.requestDM2(any(), eq(true), eq(0))).thenReturn(new RequestResult<>(false, listOf(packet2)));
+        when(dtcModule.requestDM2(any(), eq(true), eq(0)))
+                .thenReturn(new RequestResult<>(false, listOf(packet2), Collections.emptyList()));
 
         // add ACK/NACK packets to the listing for complete reality testing
         AcknowledgmentPacket packet4 = mock(AcknowledgmentPacket.class);
         destinationSpecificPackets.add(packet4);
         when(packet4.getSourceAddress()).thenReturn(3);
-        when(dtcModule.requestDM2(any(), eq(true), eq(3))).thenReturn(new RequestResult<>(false, listOf(packet4)));
+        when(dtcModule.requestDM2(any(), eq(true), eq(3)))
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet4)));
 
         // Return the modules address so that we can do the destination specific
         // calls
@@ -392,29 +389,30 @@ public class Step16ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoErrors() {
 
-        List<ParsedPacket> globalPackets = new ArrayList<>();
         DM2PreviouslyActiveDTC packet1 = mock(DM2PreviouslyActiveDTC.class);
-        globalPackets.add(packet1);
         when(packet1.getDtcs()).thenReturn(Collections.emptyList());
         when(packet1.getSourceAddress()).thenReturn(0);
         when(packet1.getMalfunctionIndicatorLampStatus()).thenReturn(LampStatus.OFF);
-        when(dtcModule.requestDM2(any(), eq(true))).thenReturn(new RequestResult<>(false, globalPackets));
+        when(dtcModule.requestDM2(any(), eq(true)))
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet1), Collections.emptyList()));
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(packet3.getSourceAddress()).thenReturn(3);
-        globalPackets.add(packet3);
+        // FIXME what was this? globalPackets.add(packet3);
 
         // Set up the destination specific packets we will be returning when
         // requested
         DM2PreviouslyActiveDTC packet2 = mock(DM2PreviouslyActiveDTC.class);
         when(packet2.getSourceAddress()).thenReturn(0);
-        when(dtcModule.requestDM2(any(), eq(true), eq(0))).thenReturn(new RequestResult<>(false, listOf(packet2)));
+        when(dtcModule.requestDM2(any(), eq(true), eq(0)))
+                .thenReturn(new RequestResult<>(false, listOf(packet2), Collections.emptyList()));
 
         // add ACK/NACK packets to the listing for complete reality testing
         AcknowledgmentPacket packet4 = mock(AcknowledgmentPacket.class);
         when(packet4.getSourceAddress()).thenReturn(3);
 
-        when(dtcModule.requestDM2(any(), eq(true), eq(3))).thenReturn(new RequestResult<>(false, listOf(packet4)));
+        when(dtcModule.requestDM2(any(), eq(true), eq(3)))
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet4)));
 
         // Return the modules address so that we can do the destination specific
         // calls
@@ -445,17 +443,16 @@ public class Step16ControllerTest extends AbstractControllerTest {
     @Test
     @TestDoc({ @TestItem(verifies = "6.1.16.4.a,b,c") })
     public void testNonOBDMilOn() {
-        List<ParsedPacket> globalPackets = new ArrayList<>();
         DM2PreviouslyActiveDTC packet1 = mock(DM2PreviouslyActiveDTC.class);
-        globalPackets.add(packet1);
         when(packet1.getDtcs()).thenReturn(Collections.emptyList());
         when(packet1.getSourceAddress()).thenReturn(0);
         when(packet1.getMalfunctionIndicatorLampStatus()).thenReturn(LampStatus.ON);
-        when(dtcModule.requestDM2(any(), eq(true))).thenReturn(new RequestResult<>(false, globalPackets));
+        when(dtcModule.requestDM2(any(), eq(true)))
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet1), Collections.emptyList()));
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(packet3.getResponse()).thenReturn(Response.NACK);
-        globalPackets.add(packet3);
+        // FIXME what was this? globalPackets.add(packet3);
 
         // Set up the destination specific packets we will be returning when
         // requested
@@ -515,29 +512,29 @@ public class Step16ControllerTest extends AbstractControllerTest {
     @TestDoc({ @TestItem(verifies = "6.1.16.4.a,b") })
     public void testResponseNotNACK() {
 
-        List<ParsedPacket> globalPackets = new ArrayList<>();
         DM2PreviouslyActiveDTC packet1 = mock(DM2PreviouslyActiveDTC.class);
-        globalPackets.add(packet1);
         when(packet1.getSourceAddress()).thenReturn(0);
         when(packet1.getMalfunctionIndicatorLampStatus()).thenReturn(LampStatus.OFF);
 
         AcknowledgmentPacket packet3 = mock(AcknowledgmentPacket.class);
         when(packet3.getResponse()).thenReturn(Response.ACK);
         when(packet3.getSourceAddress()).thenReturn(3);
-        globalPackets.add(packet3);
 
-        when(dtcModule.requestDM2(any(), eq(true))).thenReturn(new RequestResult<>(false, globalPackets));
+        when(dtcModule.requestDM2(any(), eq(true))).thenReturn(
+                new RequestResult<>(false, Collections.singletonList(packet1), Collections.singletonList(packet3)));
 
         // Set up the destination specific packets we will be returning when
         // requested
         DM2PreviouslyActiveDTC packet2 = mock(DM2PreviouslyActiveDTC.class);
         when(packet2.getSourceAddress()).thenReturn(0);
-        when(dtcModule.requestDM2(any(), eq(true), eq(0))).thenReturn(new RequestResult<>(false, listOf(packet2)));
+        when(dtcModule.requestDM2(any(), eq(true), eq(0)))
+                .thenReturn(new RequestResult<>(false, listOf(packet2), Collections.emptyList()));
 
         // add ACK/NACK packets to the listing for complete reality testing
         DM2PreviouslyActiveDTC packet4 = mock(DM2PreviouslyActiveDTC.class);
         when(packet4.getSourceAddress()).thenReturn(3);
-        when(dtcModule.requestDM2(any(), eq(true), eq(3))).thenReturn(new RequestResult<>(false, listOf(packet4)));
+        when(dtcModule.requestDM2(any(), eq(true), eq(3)))
+                .thenReturn(new RequestResult<>(false, listOf(packet4), Collections.emptyList()));
 
         // Return the modules address so that we can do the destination specific
         // calls
@@ -586,28 +583,29 @@ public class Step16ControllerTest extends AbstractControllerTest {
     @TestDoc({ @TestItem(verifies = "6.1.16.4.a") })
     public void testResponsesAreDifferent() {
 
-        List<ParsedPacket> globalPackets = new ArrayList<>();
         DM2PreviouslyActiveDTC packet1 = mock(DM2PreviouslyActiveDTC.class);
-        globalPackets.add(packet1);
         when(packet1.getSourceAddress()).thenReturn(0);
         when(packet1.getMalfunctionIndicatorLampStatus()).thenReturn(LampStatus.OFF);
-        when(dtcModule.requestDM2(any(), eq(true))).thenReturn(new RequestResult<>(false, globalPackets));
+        when(dtcModule.requestDM2(any(), eq(true)))
+                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet1), Collections.emptyList()));
 
         DM2PreviouslyActiveDTC packet3 = mock(DM2PreviouslyActiveDTC.class);
         when(packet3.getMalfunctionIndicatorLampStatus()).thenReturn(LampStatus.OFF);
         when(packet3.getSourceAddress()).thenReturn(3);
-        globalPackets.add(packet3);
+        // FIXME what was this? globalPackets.add(packet3);
 
         // Set up the destination specific packets we will be returning when
         // requested
         DM2PreviouslyActiveDTC packet2 = mock(DM2PreviouslyActiveDTC.class);
         when(packet2.getSourceAddress()).thenReturn(0);
-        when(dtcModule.requestDM2(any(), eq(true), eq(0))).thenReturn(new RequestResult<>(false, listOf(packet2)));
+        when(dtcModule.requestDM2(any(), eq(true), eq(0)))
+                .thenReturn(new RequestResult<>(false, listOf(packet2), Collections.emptyList()));
 
         // add ACK/NACK packets to the listing for complete reality testing
         AcknowledgmentPacket packet4 = mock(AcknowledgmentPacket.class);
         when(packet4.getSourceAddress()).thenReturn(3);
-        when(dtcModule.requestDM2(any(), eq(true), eq(3))).thenReturn(new RequestResult<>(false, listOf(packet4)));
+        when(dtcModule.requestDM2(any(), eq(true), eq(3)))
+                .thenReturn(new RequestResult<>(false, Collections.emptyList(), listOf(packet4)));
 
         // Return the modules address so that we can do the destination specific
         // calls

--- a/src-test/org/etools/j1939_84/modules/DTCModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/DTCModuleTest.java
@@ -272,7 +272,7 @@ public class DTCModuleTest {
         DM11ClearActiveDTCsPacket packet3 = new DM11ClearActiveDTCsPacket(
                 Packet.create(0xE800, 0x21, 0x00, 0xFF, 0xFF, 0xFF, 0xF9, 0xD3, 0xFE, 0x00));
         when(j1939.requestRaw(DM11ClearActiveDTCsPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(null, p)));
 
         String expected = "";
         expected += "10:15:30.000 Clearing Diagnostic Trouble Codes" + NL;
@@ -307,8 +307,8 @@ public class DTCModuleTest {
                 Packet.create(0xE800, 0x17, 0x00, 0xFF, 0xFF, 0xFF, 0xF9, 0xD3, 0xFE, 0x00));
         AcknowledgmentPacket packet3 = new AcknowledgmentPacket(
                 Packet.create(0xE800, 0x21, 0x00, 0xFF, 0xFF, 0xFF, 0xF9, 0xD3, 0xFE, 0x00));
-        when(j1939.requestRaw(AcknowledgmentPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
+        when(j1939.requestRaw(DM11ClearActiveDTCsPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(null, p)));
 
         String expected = "";
         expected += "10:15:30.000 Clearing Diagnostic Trouble Codes" + NL;
@@ -367,7 +367,7 @@ public class DTCModuleTest {
                 Packet.create(0xE800, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xF9, 0xD3, 0xFE, 0x00));
 
         when(j1939.requestRaw(DM11ClearActiveDTCsPacket.class, requestPacket1, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1).map(p -> new Either<>(p, null)));
+                .thenReturn(Stream.of(packet1).map(p -> new Either<>(null, p)));
 
         String expected = "";
         expected += "10:15:30.000 Clearing Diagnostic Trouble Codes" + NL;
@@ -393,8 +393,8 @@ public class DTCModuleTest {
 
         AcknowledgmentPacket packet1 = new AcknowledgmentPacket(
                 Packet.create(0xE800, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xF9, 0xD3, 0xFE, 0x00));
-        when(j1939.requestRaw(AcknowledgmentPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1).map(p -> new Either<>(p, null)));
+        when(j1939.requestRaw(DM11ClearActiveDTCsPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
+                .thenReturn(Stream.of(packet1).map(p -> new Either<>(null, p)));
 
         String expected = "";
         expected += "10:15:30.000 Clearing Diagnostic Trouble Codes" + NL;

--- a/src-test/org/etools/j1939_84/modules/DTCModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/DTCModuleTest.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import org.etools.j1939_84.bus.Either;
 import org.etools.j1939_84.bus.Packet;
 import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
@@ -40,7 +41,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * @author Matt Gumbel (matt@soliddesign.net)
  *
  */
-@SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", justification = "The values returned are properly ignored on verify statements.")
+@SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
+                    justification = "The values returned are properly ignored on verify statements.")
 @RunWith(MockitoJUnitRunner.class)
 public class DTCModuleTest {
 
@@ -79,7 +81,7 @@ public class DTCModuleTest {
         DM2PreviouslyActiveDTC packet3 = new DM2PreviouslyActiveDTC(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM2PreviouslyActiveDTC.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Destination Specific DM2 Request" + NL;
@@ -108,8 +110,9 @@ public class DTCModuleTest {
         DM2PreviouslyActiveDTC packet2 = new DM2PreviouslyActiveDTC(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM2PreviouslyActiveDTC.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2)).thenReturn(Stream.of(packet1, packet2))
-                .thenReturn(Stream.of(packet1, packet2));
+                .thenReturn(Stream.of(packet1, packet2).map(p -> new Either<>(p, null)))
+                .thenReturn(Stream.of(packet1, packet2).map(p -> new Either<>(p, null)))
+                .thenReturn(Stream.of(packet1, packet2).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Destination Specific DM2 Request" + NL;
@@ -166,7 +169,7 @@ public class DTCModuleTest {
         DM2PreviouslyActiveDTC packet3 = new DM2PreviouslyActiveDTC(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM2PreviouslyActiveDTC.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Destination Specific DM2 Request" + NL;
@@ -204,7 +207,7 @@ public class DTCModuleTest {
         DM2PreviouslyActiveDTC packet3 = new DM2PreviouslyActiveDTC(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM2PreviouslyActiveDTC.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Destination Specific DM2 Request" + NL;
@@ -269,7 +272,7 @@ public class DTCModuleTest {
         DM11ClearActiveDTCsPacket packet3 = new DM11ClearActiveDTCsPacket(
                 Packet.create(0xE800, 0x21, 0x00, 0xFF, 0xFF, 0xFF, 0xF9, 0xD3, 0xFE, 0x00));
         when(j1939.requestRaw(DM11ClearActiveDTCsPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Clearing Diagnostic Trouble Codes" + NL;
@@ -304,8 +307,8 @@ public class DTCModuleTest {
                 Packet.create(0xE800, 0x17, 0x00, 0xFF, 0xFF, 0xFF, 0xF9, 0xD3, 0xFE, 0x00));
         AcknowledgmentPacket packet3 = new AcknowledgmentPacket(
                 Packet.create(0xE800, 0x21, 0x00, 0xFF, 0xFF, 0xFF, 0xF9, 0xD3, 0xFE, 0x00));
-        when(j1939.requestRaw(DM11ClearActiveDTCsPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+        when(j1939.requestRaw(AcknowledgmentPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Clearing Diagnostic Trouble Codes" + NL;
@@ -364,7 +367,7 @@ public class DTCModuleTest {
                 Packet.create(0xE800, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xF9, 0xD3, 0xFE, 0x00));
 
         when(j1939.requestRaw(DM11ClearActiveDTCsPacket.class, requestPacket1, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1));
+                .thenReturn(Stream.of(packet1).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Clearing Diagnostic Trouble Codes" + NL;
@@ -390,8 +393,8 @@ public class DTCModuleTest {
 
         AcknowledgmentPacket packet1 = new AcknowledgmentPacket(
                 Packet.create(0xE800, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xF9, 0xD3, 0xFE, 0x00));
-        when(j1939.requestRaw(DM11ClearActiveDTCsPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1));
+        when(j1939.requestRaw(AcknowledgmentPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
+                .thenReturn(Stream.of(packet1).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Clearing Diagnostic Trouble Codes" + NL;
@@ -423,7 +426,7 @@ public class DTCModuleTest {
         DM12MILOnEmissionDTCPacket packet3 = new DM12MILOnEmissionDTCPacket(
                 Packet.create(pgn, 0x21, 0, 0, 0, 0, 0, 0, 0, 0));
         when(j1939.requestMultiple(DM12MILOnEmissionDTCPacket.class, requestPacket))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM12 Request" + NL;
@@ -469,7 +472,8 @@ public class DTCModuleTest {
                 0x10,
                 0x04,
                 0x00));
-        when(j1939.requestMultiple(DM12MILOnEmissionDTCPacket.class, requestPacket)).thenReturn(Stream.of(packet1));
+        when(j1939.requestMultiple(DM12MILOnEmissionDTCPacket.class, requestPacket))
+                .thenReturn(Stream.of(packet1).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM12 Request" + NL;
@@ -525,7 +529,7 @@ public class DTCModuleTest {
         DM2PreviouslyActiveDTC packet3 = new DM2PreviouslyActiveDTC(
                 Packet.create(pgn, 0x21, 0, 0, 0, 0, 0, 0, 0, 0));
         when(j1939.requestMultiple(DM2PreviouslyActiveDTC.class, requestPacket))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM2 Request" + NL;
@@ -562,7 +566,7 @@ public class DTCModuleTest {
         DM23PreviouslyMILOnEmissionDTCPacket packet3 = new DM23PreviouslyMILOnEmissionDTCPacket(
                 Packet.create(pgn, 0x21, 0, 0, 0, 0, 0, 0, 0, 0));
         when(j1939.requestMultiple(DM23PreviouslyMILOnEmissionDTCPacket.class, requestPacket))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM23 Request" + NL;
@@ -609,7 +613,7 @@ public class DTCModuleTest {
                 0x04,
                 0x00));
         when(j1939.requestMultiple(DM23PreviouslyMILOnEmissionDTCPacket.class, requestPacket))
-                .thenReturn(Stream.of(packet1));
+                .thenReturn(Stream.of(packet1).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM23 Request" + NL;
@@ -663,7 +667,7 @@ public class DTCModuleTest {
         DM28PermanentEmissionDTCPacket packet3 = new DM28PermanentEmissionDTCPacket(
                 Packet.create(pgn, 0x21, 0, 0, 0, 0, 0, 0, 0, 0));
         when(j1939.requestMultiple(DM28PermanentEmissionDTCPacket.class, requestPacket))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM28 Request" + NL;
@@ -710,7 +714,8 @@ public class DTCModuleTest {
                 0x04,
                 0x00));
 
-        when(j1939.requestMultiple(DM28PermanentEmissionDTCPacket.class, requestPacket)).thenReturn(Stream.of(packet1));
+        when(j1939.requestMultiple(DM28PermanentEmissionDTCPacket.class, requestPacket))
+                .thenReturn(Stream.of(packet1).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM28 Request" + NL;
@@ -773,7 +778,8 @@ public class DTCModuleTest {
                 0x10,
                 0x04,
                 0x00));
-        when(j1939.requestMultiple(DM2PreviouslyActiveDTC.class, requestPacket)).thenReturn(Stream.of(packet1));
+        when(j1939.requestMultiple(DM2PreviouslyActiveDTC.class, requestPacket))
+                .thenReturn(Stream.of(packet1).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM2 Request" + NL;
@@ -827,7 +833,7 @@ public class DTCModuleTest {
         DM6PendingEmissionDTCPacket packet3 = new DM6PendingEmissionDTCPacket(
                 Packet.create(pgn, 0x21, 0, 0, 0, 0, 0, 0, 0, 0));
         when(j1939.requestMultiple(DM6PendingEmissionDTCPacket.class, requestPacket))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM6 Request" + NL;
@@ -873,7 +879,8 @@ public class DTCModuleTest {
                 0x10,
                 0x04,
                 0x00));
-        when(j1939.requestMultiple(DM6PendingEmissionDTCPacket.class, requestPacket)).thenReturn(Stream.of(packet1));
+        when(j1939.requestMultiple(DM6PendingEmissionDTCPacket.class, requestPacket))
+                .thenReturn(Stream.of(packet1).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM6 Request" + NL;

--- a/src-test/org/etools/j1939_84/modules/DiagnosticReadinessModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/DiagnosticReadinessModuleTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import org.etools.j1939_84.bus.Either;
 import org.etools.j1939_84.bus.Packet;
 import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.bus.j1939.packets.CompositeMonitoredSystem;
@@ -46,7 +47,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * @author Matt Gumbel (matt@soliddesign.net)
  *
  */
-@SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", justification = "The values returned are properly ignored on verify statements.")
+@SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
+                    justification = "The values returned are properly ignored on verify statements.")
 @RunWith(MockitoJUnitRunner.class)
 public class DiagnosticReadinessModuleTest {
 
@@ -107,7 +109,7 @@ public class DiagnosticReadinessModuleTest {
         DM20MonitorPerformanceRatioPacket packet3 = new DM20MonitorPerformanceRatioPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM20MonitorPerformanceRatioPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM20 Request" + NL;
@@ -161,7 +163,7 @@ public class DiagnosticReadinessModuleTest {
         DM20MonitorPerformanceRatioPacket packet3 = new DM20MonitorPerformanceRatioPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM20MonitorPerformanceRatioPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM20 Request" + NL;
@@ -206,7 +208,7 @@ public class DiagnosticReadinessModuleTest {
         DM20MonitorPerformanceRatioPacket packet3 = new DM20MonitorPerformanceRatioPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM20MonitorPerformanceRatioPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM20 Request" + NL;
@@ -251,7 +253,7 @@ public class DiagnosticReadinessModuleTest {
         DM20MonitorPerformanceRatioPacket packet3 = new DM20MonitorPerformanceRatioPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM20MonitorPerformanceRatioPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         List<DM20MonitorPerformanceRatioPacket> packets = instance.getDM20Packets(null, false);
         assertEquals(3, packets.size());
@@ -270,7 +272,7 @@ public class DiagnosticReadinessModuleTest {
         DM21DiagnosticReadinessPacket packet3 = new DM21DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM21DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet3));
+                .thenReturn(Stream.of(packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Destination Specific DM21 Request" + NL;
@@ -317,7 +319,7 @@ public class DiagnosticReadinessModuleTest {
         DM21DiagnosticReadinessPacket packet3 = new DM21DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM21DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet3));
+                .thenReturn(Stream.of(packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Destination Specific DM21 Request" + NL;
@@ -351,7 +353,7 @@ public class DiagnosticReadinessModuleTest {
         DM26TripDiagnosticReadinessPacket packet3 = new DM26TripDiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM26TripDiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM26 Request" + NL;
@@ -402,7 +404,7 @@ public class DiagnosticReadinessModuleTest {
         DM26TripDiagnosticReadinessPacket packet3 = new DM26TripDiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM26TripDiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM26 Request" + NL;
@@ -435,7 +437,7 @@ public class DiagnosticReadinessModuleTest {
         DM26TripDiagnosticReadinessPacket packet3 = new DM26TripDiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM26TripDiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM26 Request" + NL;
@@ -468,7 +470,7 @@ public class DiagnosticReadinessModuleTest {
         DM26TripDiagnosticReadinessPacket packet3 = new DM26TripDiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM26TripDiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         List<DM26TripDiagnosticReadinessPacket> packets = instance.getDM26Packets(null, false);
         assertEquals(3, packets.size());
@@ -491,7 +493,7 @@ public class DiagnosticReadinessModuleTest {
         DM5DiagnosticReadinessPacket packet3 = new DM5DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM5DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM5 Request" + NL;
@@ -527,7 +529,7 @@ public class DiagnosticReadinessModuleTest {
         DM5DiagnosticReadinessPacket packet3 = new DM5DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM5DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM5 Request" + NL;
@@ -580,7 +582,7 @@ public class DiagnosticReadinessModuleTest {
         DM5DiagnosticReadinessPacket packet3 = new DM5DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM5DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM5 Request" + NL;
@@ -616,7 +618,7 @@ public class DiagnosticReadinessModuleTest {
         DM5DiagnosticReadinessPacket packet3 = new DM5DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM5DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         List<DM5DiagnosticReadinessPacket> packets = instance.getDM5Packets(null, false);
         assertEquals(3, packets.size());
@@ -717,7 +719,7 @@ public class DiagnosticReadinessModuleTest {
         DM5DiagnosticReadinessPacket packet3 = new DM5DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 19, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM5DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet11, packet2, packet22, packet3));
+                .thenReturn(Stream.of(packet1, packet11, packet2, packet22, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM5 Request" + NL;
@@ -823,7 +825,7 @@ public class DiagnosticReadinessModuleTest {
         DM20MonitorPerformanceRatioPacket packet3 = new DM20MonitorPerformanceRatioPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM20MonitorPerformanceRatioPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM20 Request" + NL;
@@ -890,7 +892,7 @@ public class DiagnosticReadinessModuleTest {
         DM21DiagnosticReadinessPacket packet3 = new DM21DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x77, 0x88));
         when(j1939.requestRaw(DM21DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM21 Request" + NL;
@@ -934,7 +936,7 @@ public class DiagnosticReadinessModuleTest {
         DM21DiagnosticReadinessPacket packet1 = new DM21DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88));
         when(j1939.requestRaw(DM21DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1));
+                .thenReturn(Stream.of(packet1).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM21 Request" + NL;
@@ -970,7 +972,7 @@ public class DiagnosticReadinessModuleTest {
         DM21DiagnosticReadinessPacket packet1 = new DM21DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88));
         when(j1939.requestRaw(DM21DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1));
+                .thenReturn(Stream.of(packet1).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM21 Request" + NL;
@@ -1022,7 +1024,7 @@ public class DiagnosticReadinessModuleTest {
         DM21DiagnosticReadinessPacket packet1 = new DM21DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x00, 0x00));
         when(j1939.requestRaw(DM21DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1));
+                .thenReturn(Stream.of(packet1).map(p -> new Either<>(p, null)));
 
         instance.reportDM21(listener);
 
@@ -1044,7 +1046,7 @@ public class DiagnosticReadinessModuleTest {
         DM26TripDiagnosticReadinessPacket packet3 = new DM26TripDiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM26TripDiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM26 Request" + NL;
@@ -1117,7 +1119,7 @@ public class DiagnosticReadinessModuleTest {
         DM5DiagnosticReadinessPacket packet3 = new DM5DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM5DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM5 Request" + NL;
@@ -1382,7 +1384,7 @@ public class DiagnosticReadinessModuleTest {
         DM21DiagnosticReadinessPacket packet3 = new DM21DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM21DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM21 Request" + NL;
@@ -1435,7 +1437,7 @@ public class DiagnosticReadinessModuleTest {
         DM21DiagnosticReadinessPacket packet3 = new DM21DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM21DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM21 Request" + NL;
@@ -1483,7 +1485,7 @@ public class DiagnosticReadinessModuleTest {
         DM21DiagnosticReadinessPacket packet3 = new DM21DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM21DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM21 Request" + NL;
@@ -1531,7 +1533,7 @@ public class DiagnosticReadinessModuleTest {
         DM5DiagnosticReadinessPacket packet3 = new DM5DiagnosticReadinessPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
         when(j1939.requestRaw(DM5DiagnosticReadinessPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM5 Request" + NL;

--- a/src-test/org/etools/j1939_84/modules/EngineSpeedModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/EngineSpeedModuleTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import org.etools.j1939_84.bus.Either;
 import org.etools.j1939_84.bus.Packet;
 import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.bus.j1939.packets.EngineSpeedPacket;
@@ -73,7 +74,8 @@ public class EngineSpeedModuleTest {
             "EngineSpeedPacketTest.testGetEngineSpeedAtZero" }))
     public void testEngineKOEO_0() {
         EngineSpeedPacket packet = getEngineSpeedPacket(0);
-        when(j1939.read(EngineSpeedPacket.class, 0x00, 300, TimeUnit.MILLISECONDS)).thenReturn(Optional.of(packet));
+        when(j1939.read(EngineSpeedPacket.class, 0x00, 300, TimeUnit.MILLISECONDS))
+                .thenReturn(Optional.of(new Either<>(packet, null)));
         assertTrue(instance.isEngineCommunicating());
         assertTrue(instance.isEngineNotRunning());
     }
@@ -83,7 +85,8 @@ public class EngineSpeedModuleTest {
             "EngineSpeedPacketTest.testGetEngineSpeedAndToStringAt300" }))
     public void testEngineKOEO_300() {
         EngineSpeedPacket packet = getEngineSpeedPacket(300 * 8);
-        when(j1939.read(EngineSpeedPacket.class, 0x00, 300, TimeUnit.MILLISECONDS)).thenReturn(Optional.of(packet));
+        when(j1939.read(EngineSpeedPacket.class, 0x00, 300, TimeUnit.MILLISECONDS))
+                .thenReturn(Optional.of(new Either<>(packet, null)));
         assertTrue(instance.isEngineCommunicating());
         assertTrue(instance.isEngineNotRunning());
     }
@@ -92,7 +95,8 @@ public class EngineSpeedModuleTest {
     @TestDoc(@TestItem(description = "Verify KOER is identified when PGN 61444 speed 301 is on the bus."))
     public void testEngineKOER_301() {
         EngineSpeedPacket packet = getEngineSpeedPacket(301 * 8);
-        when(j1939.read(EngineSpeedPacket.class, 0x00, 300, TimeUnit.MILLISECONDS)).thenReturn(Optional.of(packet));
+        when(j1939.read(EngineSpeedPacket.class, 0x00, 300, TimeUnit.MILLISECONDS))
+                .thenReturn(Optional.of(new Either<>(packet, null)));
         assertTrue(instance.isEngineCommunicating());
         assertFalse(instance.isEngineNotRunning());
     }
@@ -110,7 +114,8 @@ public class EngineSpeedModuleTest {
     @TestDoc(@TestItem(description = "Verify KOER is identified when PGN 61444 speed (0xFE00-1)/8 RPM is on the bus."))
     public void testKOER_2500() {
         EngineSpeedPacket packet = getEngineSpeedPacket(0xFE00 - 1);
-        when(j1939.read(EngineSpeedPacket.class, 0x00, 300, TimeUnit.MILLISECONDS)).thenReturn(Optional.of(packet));
+        when(j1939.read(EngineSpeedPacket.class, 0x00, 300, TimeUnit.MILLISECONDS))
+                .thenReturn(Optional.of(new Either<>(packet, null)));
         assertTrue(instance.isEngineCommunicating());
         assertFalse(instance.isEngineNotRunning());
     }
@@ -121,7 +126,8 @@ public class EngineSpeedModuleTest {
                                "EngineSpeedPacketTest.testGetEngineSpeedAndToStringAtError" }))
     public void testKOER_error() {
         EngineSpeedPacket packet = getEngineSpeedPacket(0xFE00);
-        when(j1939.read(EngineSpeedPacket.class, 0x00, 300, TimeUnit.MILLISECONDS)).thenReturn(Optional.of(packet));
+        when(j1939.read(EngineSpeedPacket.class, 0x00, 300, TimeUnit.MILLISECONDS))
+                .thenReturn(Optional.of(new Either<>(packet, null)));
         assertTrue(instance.isEngineCommunicating());
         assertFalse(instance.isEngineNotRunning());
     }
@@ -132,7 +138,8 @@ public class EngineSpeedModuleTest {
                                "EngineSpeedPacketTest.testGetEngineSpeedAndToStringAtNotAvailable" }))
     public void testKOER_not_available() {
         EngineSpeedPacket packet = getEngineSpeedPacket(0xFFFF);
-        when(j1939.read(EngineSpeedPacket.class, 0x00, 300, TimeUnit.MILLISECONDS)).thenReturn(Optional.of(packet));
+        when(j1939.read(EngineSpeedPacket.class, 0x00, 300, TimeUnit.MILLISECONDS))
+                .thenReturn(Optional.of(new Either<>(packet, null)));
         assertTrue(instance.isEngineCommunicating());
         assertFalse(instance.isEngineNotRunning());
     }

--- a/src-test/org/etools/j1939_84/modules/OBDTestsModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/OBDTestsModuleTest.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import org.etools.j1939_84.bus.Either;
 import org.etools.j1939_84.bus.Packet;
 import org.etools.j1939_84.bus.j1939.BusResult;
 import org.etools.j1939_84.bus.j1939.J1939;
@@ -37,7 +38,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * @author Matt Gumbel (matt@soliddesign.net)
  *
  */
-@SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", justification = "The values returned are properly ignored on verify statements.")
+@SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
+                    justification = "The values returned are properly ignored on verify statements.")
 @RunWith(MockitoJUnitRunner.class)
 public class OBDTestsModuleTest {
 
@@ -96,21 +98,21 @@ public class OBDTestsModuleTest {
         when(j1939.requestPacket(Packet.create(0xE300, BUS_ADDR, true, 0xF7, 0x66, 0x00, 0x1F, 0xFF, 0xFF, 0xFF, 0xFF),
                 DM30ScaledTestResultsPacket.class,
                 0x0,
-                3)).thenReturn(Optional.of(engineDm30PacketSpn102));
+                3)).thenReturn(Optional.of(new Either<>(engineDm30PacketSpn102, null)));
 
         DM30ScaledTestResultsPacket engineDm30PacketSpn512 = new DM30ScaledTestResultsPacket(
                 Packet.create(0xA400, 0x00, 0xF7, 0x00, 0x02, 0x12, 0xD0, 0x00, 0x00, 0xFB, 0xFF, 0xFF, 0xFF, 0xFF));
         when(j1939.requestPacket(Packet.create(0xE300, BUS_ADDR, true, 0xF7, 0x00, 0x02, 0x1F, 0xFF, 0xFF, 0xFF, 0xFF),
                 DM30ScaledTestResultsPacket.class,
                 0x00,
-                3)).thenReturn(Optional.of(engineDm30PacketSpn512));
+                3)).thenReturn(Optional.of(new Either<>(engineDm30PacketSpn512, null)));
 
         DM30ScaledTestResultsPacket engineDm30PacketSpn520348 = new DM30ScaledTestResultsPacket(
                 Packet.create(0xA400, 0x00, 0xF7, 0x9C, 0xF0, 0xFF, 0xD0, 0x00, 0x00, 0xFB, 0xFF, 0xFF, 0xFF, 0xFF));
         when(j1939.requestPacket(Packet.create(0xE300, BUS_ADDR, true, 0xF7, 0x9C, 0xF0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF),
                 DM30ScaledTestResultsPacket.class,
                 0x00,
-                3)).thenReturn(Optional.of(engineDm30PacketSpn520348));
+                3)).thenReturn(Optional.of(new Either<>(engineDm30PacketSpn520348, null)));
 
         Packet dm24RequestPacket2 = Packet.create(0xEA55, BUS_ADDR, true, 0xB6, 0xFD, 0x00);
         when(j1939.createRequestPacket(64950, 0x55)).thenReturn(dm24RequestPacket2);
@@ -124,14 +126,14 @@ public class OBDTestsModuleTest {
         when(j1939.requestPacket(Packet.create(0xE355, BUS_ADDR, true, 0xF7, 0x0C, 0x11, 0x1F, 0xFF, 0xFF, 0xFF, 0xFF),
                 DM30ScaledTestResultsPacket.class,
                 0x55,
-                3)).thenReturn(Optional.of(atDm30PacketSpn4364));
+                3)).thenReturn(Optional.of(new Either<>(atDm30PacketSpn4364, null)));
 
         DM30ScaledTestResultsPacket atDm30PacketSpn3226 = new DM30ScaledTestResultsPacket(
                 Packet.create(0xA400, 0x55, 0xF7, 0x9A, 0x0C, 0x0A, 0x00, 0x01, 0x00, 0xFB, 0xFF, 0xFF, 0xFF, 0xFF));
         when(j1939.requestPacket(Packet.create(0xE355, BUS_ADDR, true, 0xF7, 0x9A, 0x0C, 0x1F, 0xFF, 0xFF, 0xFF, 0xFF),
                 DM30ScaledTestResultsPacket.class,
                 0x55,
-                3)).thenReturn(Optional.of(atDm30PacketSpn3226));
+                3)).thenReturn(Optional.of(new Either<>(atDm30PacketSpn3226, null)));
 
         List<Integer> obdModules = Arrays.asList(new Integer[] { 0x00, 0x55 });
         instance.reportOBDTests(listener, obdModules);
@@ -235,7 +237,7 @@ public class OBDTestsModuleTest {
                 Packet.create(0xA400, 0x00, 0xF7, 0x66, 0x00, 0x12, 0xD0, 0x00, 0x00, 0xFA, 0xFF, 0xFF, 0xFF, 0xFF));
 
         when(j1939.requestPacket(any(Packet.class), eq(DM30ScaledTestResultsPacket.class), eq(0x00), eq(3)))
-                .thenReturn(Optional.of(engineDm30Packet));
+                .thenReturn(Optional.of(new Either<>(engineDm30Packet, null)));
 
         DM24SPNSupportPacket engineDm24Packet = new DM24SPNSupportPacket(
                 Packet.create(64950, 0x00, 0x66, 0x00, 0x1B, 0x01));

--- a/src-test/org/etools/j1939_84/modules/VehicleInformationModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/VehicleInformationModuleTest.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 
 import org.etools.j1939_84.bus.Bus;
 import org.etools.j1939_84.bus.BusException;
+import org.etools.j1939_84.bus.Either;
 import org.etools.j1939_84.bus.Packet;
 import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.bus.j1939.packets.AddressClaimPacket;
@@ -82,7 +83,7 @@ public class VehicleInformationModuleTest {
     public void testGetEngineFamilyName() throws Exception {
         DM56EngineFamilyPacket response = mock(DM56EngineFamilyPacket.class);
         when(response.getFamilyName()).thenReturn("family");
-        when(j1939.requestMultiple(DM56EngineFamilyPacket.class)).thenReturn(Stream.of(response));
+        when(j1939.requestMultiple(DM56EngineFamilyPacket.class)).thenReturn(Stream.of(new Either<>(response, null)));
 
         String actual = instance.getEngineFamilyName();
         instance.getEngineFamilyName(); // Make sure it's cached
@@ -115,7 +116,8 @@ public class VehicleInformationModuleTest {
         when(response1.getFamilyName()).thenReturn("name1");
         DM56EngineFamilyPacket response2 = mock(DM56EngineFamilyPacket.class);
         when(response2.getFamilyName()).thenReturn("name2");
-        when(j1939.requestMultiple(DM56EngineFamilyPacket.class)).thenReturn(Stream.of(response1, response2));
+        when(j1939.requestMultiple(DM56EngineFamilyPacket.class))
+                .thenReturn(Stream.of(new Either<>(response1, null), new Either<>(response2, null)));
 
         try {
             instance.getEngineFamilyName();
@@ -133,7 +135,7 @@ public class VehicleInformationModuleTest {
     public void testGetEngineModelYear() throws Exception {
         DM56EngineFamilyPacket response = mock(DM56EngineFamilyPacket.class);
         when(response.getEngineModelYear()).thenReturn(123);
-        when(j1939.requestMultiple(DM56EngineFamilyPacket.class)).thenReturn(Stream.of(response));
+        when(j1939.requestMultiple(DM56EngineFamilyPacket.class)).thenReturn(Stream.of(new Either<>(response, null)));
 
         Integer actual = instance.getEngineModelYear();
         instance.getEngineModelYear(); // Make sure it's cached
@@ -165,7 +167,8 @@ public class VehicleInformationModuleTest {
         when(response1.getEngineModelYear()).thenReturn(123);
         DM56EngineFamilyPacket response2 = mock(DM56EngineFamilyPacket.class);
         when(response2.getEngineModelYear()).thenReturn(456);
-        when(j1939.requestMultiple(DM56EngineFamilyPacket.class)).thenReturn(Stream.of(response1, response2));
+        when(j1939.requestMultiple(DM56EngineFamilyPacket.class))
+                .thenReturn(Stream.of(new Either<>(response1, null), new Either<>(response2, null)));
 
         try {
             instance.getEngineModelYear();
@@ -184,7 +187,8 @@ public class VehicleInformationModuleTest {
     public void testGetVin() throws Exception {
         VehicleIdentificationPacket response = mock(VehicleIdentificationPacket.class);
         when(response.getVin()).thenReturn("vin");
-        when(j1939.requestMultiple(VehicleIdentificationPacket.class)).thenReturn(Stream.of(response));
+        when(j1939.requestMultiple(VehicleIdentificationPacket.class))
+                .thenReturn(Stream.of(new Either<>(response, null)));
 
         String vin = instance.getVin();
         instance.getVin(); // Make sure it's cached
@@ -219,7 +223,8 @@ public class VehicleInformationModuleTest {
         when(response1.getVin()).thenReturn("vin1");
         VehicleIdentificationPacket response2 = mock(VehicleIdentificationPacket.class);
         when(response2.getVin()).thenReturn("vin2");
-        when(j1939.requestMultiple(VehicleIdentificationPacket.class)).thenReturn(Stream.of(response1, response2));
+        when(j1939.requestMultiple(VehicleIdentificationPacket.class))
+                .thenReturn(Stream.of(new Either<>(response1, null), new Either<>(response2, null)));
 
         try {
             instance.getVin();
@@ -242,7 +247,8 @@ public class VehicleInformationModuleTest {
         AddressClaimPacket packet2 = new AddressClaimPacket(Packet.parse("18EEFF3D 00 00 00 00 00 00 00 00"));
         AddressClaimPacket packet3 = new AddressClaimPacket(Packet.parse("18EEFF00 00 00 40 05 00 00 65 14"));
         when(j1939.requestMultiple(AddressClaimPacket.class, requestPacket))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(new Either<>(packet1, null), new Either<>(packet2, null),
+                        new Either<>(packet3, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global Request for Address Claim" + NL;
@@ -287,7 +293,8 @@ public class VehicleInformationModuleTest {
         when(j1939.createRequestPacket(pgn, 0xFF)).thenReturn(requestPacket);
 
         AddressClaimPacket packet1 = new AddressClaimPacket(Packet.parse("18EEFF55 10 F7 45 01 00 45 00 01"));
-        when(j1939.requestMultiple(AddressClaimPacket.class, requestPacket)).thenReturn(Stream.of(packet1));
+        when(j1939.requestMultiple(AddressClaimPacket.class, requestPacket))
+                .thenReturn(Stream.of(new Either<>(packet1, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global Request for Address Claim" + NL;
@@ -346,7 +353,7 @@ public class VehicleInformationModuleTest {
         DM19CalibrationInformationPacket packet3 = new DM19CalibrationInformationPacket(
                 Packet.create(pgn, 0x21, calBytes3));
         when(j1939.requestMultiple(DM19CalibrationInformationPacket.class, requestPacket))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM19 (Calibration Information) Request" + NL;
@@ -380,7 +387,7 @@ public class VehicleInformationModuleTest {
                 Packet.create(pgn, 0x21, new byte[] {}));
 
         when(j1939.requestRaw(DM19CalibrationInformationPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 DS DM19 (Calibration Information) Request to 00" + NL;
@@ -456,7 +463,7 @@ public class VehicleInformationModuleTest {
         ComponentIdentificationPacket packet2 = new ComponentIdentificationPacket(Packet.create(pgn, 0x17, bytes2));
         ComponentIdentificationPacket packet3 = new ComponentIdentificationPacket(Packet.create(pgn, 0x21, bytes3));
         when(j1939.requestMultiple(ComponentIdentificationPacket.class, requestPacket))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global Component Identification Request" + NL;
@@ -539,7 +546,7 @@ public class VehicleInformationModuleTest {
         DM56EngineFamilyPacket packet2 = new DM56EngineFamilyPacket(Packet.create(pgn, 0x17, bytes));
         DM56EngineFamilyPacket packet3 = new DM56EngineFamilyPacket(Packet.create(pgn, 0x21, bytes));
         when(j1939.requestMultiple(DM56EngineFamilyPacket.class, requestPacket))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global DM56 Request" + NL;
@@ -601,7 +608,8 @@ public class VehicleInformationModuleTest {
 
         EngineHoursPacket packet1 = new EngineHoursPacket(Packet.create(pgn, 0x00, 1, 2, 3, 4, 5, 6, 7, 8));
         EngineHoursPacket packet2 = new EngineHoursPacket(Packet.create(pgn, 0x01, 8, 7, 6, 5, 4, 3, 2, 1));
-        when(j1939.requestMultiple(EngineHoursPacket.class, requestPacket)).thenReturn(Stream.of(packet1, packet2));
+        when(j1939.requestMultiple(EngineHoursPacket.class, requestPacket))
+                .thenReturn(Stream.of(packet1, packet2).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Engine Hours Request" + NL;
@@ -654,7 +662,7 @@ public class VehicleInformationModuleTest {
                 Packet.create(pgn, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF));
 
         when(j1939.read(HighResVehicleDistancePacket.class, 3, TimeUnit.SECONDS))
-                .thenReturn(Stream.of(packet0, packet1, packet2, packetFF));
+                .thenReturn(Stream.of(packet0, packet1, packet2, packetFF).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Vehicle Distance" + NL;
@@ -682,7 +690,7 @@ public class VehicleInformationModuleTest {
                 Packet.create(pgn, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF));
 
         when(j1939.read(TotalVehicleDistancePacket.class, 300, TimeUnit.MILLISECONDS))
-                .thenReturn(Stream.of(packet2, packet1, packet0, packetFF));
+                .thenReturn(Stream.of(packet2, packet1, packet0, packetFF).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Vehicle Distance" + NL;
@@ -726,7 +734,7 @@ public class VehicleInformationModuleTest {
         VehicleIdentificationPacket packet2 = new VehicleIdentificationPacket(Packet.create(pgn, 0x17, vinBytes));
         VehicleIdentificationPacket packet3 = new VehicleIdentificationPacket(Packet.create(pgn, 0x21, vinBytes));
         when(j1939.requestMultiple(VehicleIdentificationPacket.class, requestPacket))
-                .thenReturn(Stream.of(packet1, packet2, packet3));
+                .thenReturn(Stream.of(packet1, packet2, packet3).map(p -> new Either<>(p, null)));
 
         String expected = "";
         expected += "10:15:30.000 Global VIN Request" + NL;

--- a/src-test/org/etools/j1939_84/utils/AbstractControllerTest.java
+++ b/src-test/org/etools/j1939_84/utils/AbstractControllerTest.java
@@ -5,8 +5,6 @@ package org.etools.j1939_84.utils;
 
 import static org.mockito.Mockito.verify;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.Executor;
 
 import org.etools.j1939_84.bus.j1939.J1939;
@@ -20,8 +18,8 @@ import org.mockito.ArgumentCaptor;
 /**
  * @author Marianne Schaefer (marianne.m.schaefer@gmail.com)
  *
- * This class provides the basic method for running a test on a
- * class that extends {@link Controller}.
+ *         This class provides the basic method for running a test on a class
+ *         that extends {@link Controller}.
  *
  */
 public abstract class AbstractControllerTest {
@@ -36,23 +34,9 @@ public abstract class AbstractControllerTest {
     private VehicleInformationModule vehicleInformationModule;
 
     /**
-     * This method takes an object, creates a list of the same type of objects, adds
-     * the original object to the newly created list and then returns the list.
-     *
-     * @param <T>
-     * @param item
-     * @return List<T>
-     */
-    protected <T> List<T> listOf(T item) {
-        List<T> result = new ArrayList<>();
-        result.add(item);
-        return result;
-    }
-
-    /**
      * This method will execute a test and capture the results for testing
-     * verification. This method also performs the verification of the j1939 mock
-     * used in this method.
+     * verification. This method also performs the verification of the j1939
+     * mock used in this method.
      *
      */
     protected void runTest() {
@@ -61,7 +45,8 @@ public abstract class AbstractControllerTest {
         verify(executor).execute(runnableCaptor.capture());
         runnableCaptor.getValue().run();
 
-        // Since we these interactions are mocked for every test that extends this
+        // Since we these interactions are mocked for every test that extends
+        // this
         // class, we need to verify them here.
         verify(engineSpeedModule).setJ1939(j1939);
         verify(vehicleInformationModule).setJ1939(j1939);
@@ -70,14 +55,20 @@ public abstract class AbstractControllerTest {
     /**
      * Constructor method of the class.
      *
-     * @param instance - Controller class object under test
-     * @param listener - TestResultsListener with a mocked
-     * ResultsListener
-     * @param j1939 - must be mock
-     * @param engineSpeedModule - must be mock
-     * @param reportFileModule - must be mock
-     * @param executor - can't be null
-     * @param vehicleInformationModule - must be mock
+     * @param instance
+     *            - Controller class object under test
+     * @param listener
+     *            - TestResultsListener with a mocked ResultsListener
+     * @param j1939
+     *            - must be mock
+     * @param engineSpeedModule
+     *            - must be mock
+     * @param reportFileModule
+     *            - must be mock
+     * @param executor
+     *            - can't be null
+     * @param vehicleInformationModule
+     *            - must be mock
      */
     protected void setup(Controller instance,
             TestResultsListener listener,

--- a/src/org/etools/j1939_84/bus/Either.java
+++ b/src/org/etools/j1939_84/bus/Either.java
@@ -1,3 +1,7 @@
+/**
+ * Copyright 2019 Equipment & Tool Institute
+ */
+
 package org.etools.j1939_84.bus;
 
 import java.util.Optional;
@@ -26,15 +30,19 @@ public class Either<L, R> {
 
     @SuppressWarnings("unchecked")
     public <C> C as(Class<C> cls) {
-        return left.map(l -> (C) l).orElseGet(() -> (C) right.get());
+        return resolve(x -> (C) x, x -> (C) x);
     }
 
     public <A, B> Either<A, B> map(Function<L, A> lFn, Function<R, B> rFn) {
         return new Either<>(left.map(lFn), right.map(rFn));
     }
 
+    public <T> T resolve(Function<L, T> lFn, Function<R, T> rFn) {
+        return left.map(lFn).orElseGet(() -> right.map(rFn).orElseThrow());
+    }
+
     @Override
     public String toString() {
-        return map(l -> "left: " + l.toString(), r -> "right: " + r.toString()).as(String.class);
+        return resolve(l -> "left: " + l.toString(), r -> "right: " + r.toString());
     }
 }

--- a/src/org/etools/j1939_84/bus/Either.java
+++ b/src/org/etools/j1939_84/bus/Either.java
@@ -17,7 +17,7 @@ public class Either<L, R> {
     }
 
     private Either(Optional<L> l, Optional<R> r) {
-        if (l.isPresent() ^ r.isPresent()) {
+        if (!l.isPresent() ^ r.isPresent()) {
             throw new IllegalArgumentException("Either one must be null.");
         }
         left = l;
@@ -31,5 +31,10 @@ public class Either<L, R> {
 
     public <A, B> Either<A, B> map(Function<L, A> lFn, Function<R, B> rFn) {
         return new Either<>(left.map(lFn), right.map(rFn));
+    }
+
+    @Override
+    public String toString() {
+        return map(l -> "left: " + l.toString(), r -> "right: " + r.toString()).as(String.class);
     }
 }

--- a/src/org/etools/j1939_84/bus/Either.java
+++ b/src/org/etools/j1939_84/bus/Either.java
@@ -1,0 +1,35 @@
+package org.etools.j1939_84.bus;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public class Either<L, R> {
+    static public <L, R> Either<L, R> nullable(L l, R r) {
+        return new Either<>(Optional.ofNullable(l), Optional.ofNullable(r));
+    }
+
+    final public Optional<L> left;
+
+    final public Optional<R> right;
+
+    public Either(L left, R right) {
+        this(Optional.ofNullable(left), Optional.ofNullable(right));
+    }
+
+    private Either(Optional<L> l, Optional<R> r) {
+        if (l.isPresent() ^ r.isPresent()) {
+            throw new IllegalArgumentException("Either one must be null.");
+        }
+        left = l;
+        right = r;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <C> C as(Class<C> cls) {
+        return left.map(l -> (C) l).orElseGet(() -> (C) right.get());
+    }
+
+    public <A, B> Either<A, B> map(Function<L, A> lFn, Function<R, B> rFn) {
+        return new Either<>(left.map(lFn), right.map(rFn));
+    }
+}

--- a/src/org/etools/j1939_84/bus/j1939/BusResult.java
+++ b/src/org/etools/j1939_84/bus/j1939/BusResult.java
@@ -3,29 +3,39 @@
  */
 package org.etools.j1939_84.bus.j1939;
 
+import org.etools.j1939_84.bus.Either;
+import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
+
 /**
  * @author Matt Gumbel (matt@soliddesign.net)
  *
  */
 public class BusResult<T> {
 
-    private final T packet;
+    private final Either<T, AcknowledgmentPacket> packet;
     private final boolean retryUsed;
 
     /**
      *
-     * @param retryUsed boolean representing retry has been used
-     * @param packet    the packet on the bus
+     * @param retryUsed
+     *            boolean representing retry has been used
+     * @param packet
+     *            the packet on the bus
      */
-    public BusResult(boolean retryUsed, T packet) {
+    public BusResult(boolean retryUsed, Either<T, AcknowledgmentPacket> packet) {
         this.retryUsed = retryUsed;
         this.packet = packet;
+    }
+
+    public BusResult(boolean retryUsed, T packet) {
+        this.retryUsed = retryUsed;
+        this.packet = new Either<>(packet, null);
     }
 
     /**
      * @return the packets
      */
-    public T getPacket() {
+    public Either<T, AcknowledgmentPacket> getPacket() {
         return packet;
     }
 

--- a/src/org/etools/j1939_84/bus/j1939/J1939.java
+++ b/src/org/etools/j1939_84/bus/j1939/J1939.java
@@ -121,6 +121,7 @@ public class J1939 {
      *            the {@link Packet} to process
      * @return a subclass of {@link ParsedPacket}
      */
+    @SuppressWarnings("unchecked")
     private static <T extends ParsedPacket> Either<T, AcknowledgmentPacket> process(int id, Packet packet) {
         ParsedPacket pp = processRaw(id, packet);
         if (pp instanceof AcknowledgmentPacket) {
@@ -138,7 +139,6 @@ public class J1939 {
      *            the {@link Packet} to process
      * @return a subclass of {@link ParsedPacket}
      */
-    @SuppressWarnings("unchecked")
     private static <T extends ParsedPacket> Either<T, AcknowledgmentPacket> process(Packet packet) {
         return process(packet.getId(), packet);
     }
@@ -401,7 +401,8 @@ public class J1939 {
      *            the {@link TimeUnit} for the timeout
      * @return the resulting packet
      */
-    public <T extends ParsedPacket> Optional<Either<T, AcknowledgmentPacket>> read(Class<T> T, int addr, long timeout,
+    public <T extends ParsedPacket> Optional<Either<T, AcknowledgmentPacket>> read(Class<T> T, int addr,
+            long timeout,
             TimeUnit unit) {
         int pgn = getPgn(T);
         try (Stream<Packet> stream = read(timeout, unit)) {

--- a/src/org/etools/j1939_84/bus/j1939/UnknownParsedPacket.java
+++ b/src/org/etools/j1939_84/bus/j1939/UnknownParsedPacket.java
@@ -1,0 +1,12 @@
+package org.etools.j1939_84.bus.j1939;
+
+import org.etools.j1939_84.bus.Packet;
+import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
+
+public class UnknownParsedPacket extends ParsedPacket {
+
+    public UnknownParsedPacket(Packet packet) {
+        super(packet);
+    }
+
+}

--- a/src/org/etools/j1939_84/bus/j1939/UnknownParsedPacket.java
+++ b/src/org/etools/j1939_84/bus/j1939/UnknownParsedPacket.java
@@ -1,3 +1,7 @@
+/**
+ * Copyright 2019 Equipment & Tool Institute
+ */
+
 package org.etools.j1939_84.bus.j1939;
 
 import org.etools.j1939_84.bus.Packet;

--- a/src/org/etools/j1939_84/bus/j1939/packets/DM11ClearActiveDTCsPacket.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/DM11ClearActiveDTCsPacket.java
@@ -12,28 +12,28 @@ import org.etools.j1939_84.bus.Packet;
  * @author Matt Gumbel (matt@soliddesign.net)
  *
  */
-public class DM11ClearActiveDTCsPacket extends ParsedPacket {
+public class DM11ClearActiveDTCsPacket extends AcknowledgmentPacket {
 
     /**
      * The possible responses to the DM11 request
      */
-    public enum Response {
+    public enum DM11Response {
         ACK(0, "Acknowledged"), BUSY(3, "Busy"), DENIED(2, "Denied"), NACK(1, "NACK"), UNKNOWN(-1, "Unknown");
 
-        private static Response find(int value) {
-            for (Response r : Response.values()) {
+        private static DM11Response find(int value) {
+            for (DM11Response r : DM11Response.values()) {
                 if (r.value == value) {
                     return r;
                 }
             }
-            return Response.UNKNOWN;
+            return DM11Response.UNKNOWN;
         }
 
         private final String string;
 
         private final int value;
 
-        private Response(int value, String string) {
+        private DM11Response(int value, String string) {
             this.value = value;
             this.string = string;
         }
@@ -46,16 +46,11 @@ public class DM11ClearActiveDTCsPacket extends ParsedPacket {
 
     public static final int PGN = 65235;
 
-    private final Response response;
+    private final DM11Response response;
 
     public DM11ClearActiveDTCsPacket(Packet packet) {
         super(packet);
         response = parseResponse();
-    }
-
-    @Override
-    public String getName() {
-        return "DM11";
     }
 
     /**
@@ -63,18 +58,23 @@ public class DM11ClearActiveDTCsPacket extends ParsedPacket {
      *
      * @return the response
      */
-    public Response getResponse() {
+    public DM11Response getDM11Response() {
         return response;
     }
 
-    private Response parseResponse() {
+    @Override
+    public String getName() {
+        return "DM11";
+    }
+
+    private DM11Response parseResponse() {
         int responseByte = getPacket().get(0);
-        return Response.find(responseByte);
+        return DM11Response.find(responseByte);
     }
 
     @Override
     public String toString() {
-        return getStringPrefix() + "Response is " + getResponse();
+        return getStringPrefix() + "Response is " + getDM11Response();
     }
 
 }

--- a/src/org/etools/j1939_84/bus/j1939/packets/ParsedPacket.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/ParsedPacket.java
@@ -22,7 +22,9 @@ public class ParsedPacket {
      * The ASCII code for a *. It denotes the end of a field
      */
     private static final byte ASTERISK = 42;
+
     public static final double ERROR = Double.MIN_VALUE;
+
     protected static final double KM_TO_MILES_FACTOR = 0.62137119;
     public static final double NOT_AVAILABLE = Double.MAX_VALUE;
 
@@ -30,7 +32,7 @@ public class ParsedPacket {
      * Converts the given byte array into a {@link String}
      *
      * @param bytes
-     *              the byte array to convert
+     *            the byte array to convert
      * @return {@link String}
      */
     protected static String format(byte[] bytes) {
@@ -46,7 +48,8 @@ public class ParsedPacket {
     /**
      * Finds and returns the index of the asterisk in the data
      *
-     * @param data the data of interest
+     * @param data
+     *            the data of interest
      * @return the index of the asterisk, -1 if there is no asterisk
      */
     protected static int getAsteriskIndex(byte[] data) {
@@ -77,9 +80,9 @@ public class ParsedPacket {
      * instead
      *
      * @param value
-     *              the value to display as a string
+     *            the value to display as a string
      * @param units
-     *              the units to append, can be null
+     *            the units to append, can be null
      * @return the value with units appended or "not available"/"error" as
      *         applicable.
      */
@@ -99,9 +102,9 @@ public class ParsedPacket {
      * instead
      *
      * @param value
-     *              the value to display as a string
+     *            the value to display as a string
      * @param units
-     *              the units to append, can be null
+     *            the units to append, can be null
      * @return the value with units appended or "not available"/"error" as
      *         applicable.
      */
@@ -120,7 +123,7 @@ public class ParsedPacket {
      * Returns true if the given value equates to Error
      *
      * @param value
-     *              the value to evaluate
+     *            the value to evaluate
      * @return boolean
      */
     protected static boolean isError(double value) {
@@ -131,7 +134,7 @@ public class ParsedPacket {
      * Returns true if the given value equates to Not Available
      *
      * @param value
-     *              the value to evaluate
+     *            the value to evaluate
      * @return boolean
      */
     protected static boolean isNotAvailable(double value) {
@@ -139,11 +142,12 @@ public class ParsedPacket {
     }
 
     /**
-     * Searches the data for the first asterisk returning the ASCII representation
-     * between the start of the data and the asterisk. If there is no asterisk, then
-     * entire data is translated and returned as ASCII
+     * Searches the data for the first asterisk returning the ASCII
+     * representation between the start of the data and the asterisk. If there
+     * is no asterisk, then entire data is translated and returned as ASCII
      *
-     * @param data the byte array containing the field
+     * @param data
+     *            the byte array containing the field
      * @return the ASCII translation of the field data
      */
     protected static String parseField(byte[] data) {
@@ -151,12 +155,14 @@ public class ParsedPacket {
     }
 
     /**
-     * Searches the data for the first asterisk returning the ASCII representation
-     * between the start of the data and the asterisk. If there is no asterisk, then
-     * entire data is translated and returned as ASCII
+     * Searches the data for the first asterisk returning the ASCII
+     * representation between the start of the data and the asterisk. If there
+     * is no asterisk, then entire data is translated and returned as ASCII
      *
-     * @param data the byte array containing the field
-     * @param trim true to indicate the results should be trimmed
+     * @param data
+     *            the byte array containing the field
+     * @param trim
+     *            true to indicate the results should be trimmed
      * @return the ASCII translation of the field data
      */
     protected static String parseField(byte[] data, boolean trim) {
@@ -182,7 +188,7 @@ public class ParsedPacket {
      * Constructor
      *
      * @param packet
-     *               the {@link Packet} to wrap
+     *            the {@link Packet} to wrap
      */
     public ParsedPacket(Packet packet) {
         this.packet = packet;
@@ -208,7 +214,7 @@ public class ParsedPacket {
      * Helper method to get one byte at the given index
      *
      * @param index
-     *              the index of the byte to get
+     *            the index of the byte to get
      * @return one byte
      */
     protected byte getByte(int index) {
@@ -219,7 +225,7 @@ public class ParsedPacket {
      * Helper method to get four bytes at the given index
      *
      * @param index
-     *              the index of the byte to get
+     *            the index of the byte to get
      * @return four byte
      */
     protected long getInt(int index) {
@@ -250,20 +256,20 @@ public class ParsedPacket {
      * instead
      *
      * @param index
-     *                the index of the value
+     *            the index of the value
      * @param divisor
-     *                the divisor for scaling
+     *            the divisor for scaling
      * @return double
      */
     protected double getScaledIntValue(int index, double divisor) {
         byte upperByte = getByte(index + 3);
         switch (upperByte) {
-            case (byte) 0xFF:
-                return NOT_AVAILABLE;
-            case (byte) 0xFE:
-                return ERROR;
-            default:
-                return getInt(index) / divisor;
+        case (byte) 0xFF:
+            return NOT_AVAILABLE;
+        case (byte) 0xFE:
+            return ERROR;
+        default:
+            return getInt(index) / divisor;
         }
     }
 
@@ -273,20 +279,20 @@ public class ParsedPacket {
      * instead
      *
      * @param index
-     *                the index of the value
+     *            the index of the value
      * @param divisor
-     *                the divisor for scaling
+     *            the divisor for scaling
      * @return double
      */
     protected double getScaledShortValue(int index, double divisor) {
         byte upperByte = getByte(index + 1);
         switch (upperByte) {
-            case (byte) 0xFF:
-                return NOT_AVAILABLE;
-            case (byte) 0xFE:
-                return ERROR;
-            default:
-                return getShort(index) / divisor;
+        case (byte) 0xFF:
+            return NOT_AVAILABLE;
+        case (byte) 0xFE:
+            return ERROR;
+        default:
+            return getShort(index) / divisor;
         }
     }
 
@@ -294,12 +300,12 @@ public class ParsedPacket {
      * Helper method to get two bits at the given byte index
      *
      * @param index
-     *              the index of the byte that contains the bits
+     *            the index of the byte that contains the bits
      * @param mask
-     *              the bit mask for the bits
+     *            the bit mask for the bits
      * @param shift
-     *              the number bits to shift right so the two bits are fully right
-     *              shifted
+     *            the number bits to shift right so the two bits are fully right
+     *            shifted
      * @return two bit value
      */
     protected int getShaveAndAHaircut(int index, int mask, int shift) {
@@ -310,7 +316,7 @@ public class ParsedPacket {
      * Helper method to get two bytes at the given index
      *
      * @param index
-     *              the index of the bytes to get
+     *            the index of the bytes to get
      * @return two bytes
      */
     protected int getShort(int index) {

--- a/src/org/etools/j1939_84/controllers/part1/Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step03Controller.java
@@ -2,18 +2,16 @@ package org.etools.j1939_84.controllers.part1;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 
-import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response;
 import org.etools.j1939_84.bus.j1939.packets.DM5DiagnosticReadinessPacket;
-import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.PartResultFactory;
+import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
 import org.etools.j1939_84.modules.DiagnosticReadinessModule;
@@ -60,17 +58,16 @@ public class Step03Controller extends StepController {
     protected void run() throws Throwable {
         diagnosticReadinessModule.setJ1939(getJ1939());
 
-        List<ParsedPacket> packets = diagnosticReadinessModule.requestDM5Packets(getListener(), true).getPackets();
-
-        boolean nacked = packets.stream().anyMatch(packet -> packet instanceof AcknowledgmentPacket
-                && ((AcknowledgmentPacket) packet).getResponse() == Response.NACK);
+        RequestResult<DM5DiagnosticReadinessPacket> response = diagnosticReadinessModule
+                .requestDM5Packets(getListener(), true);
+        boolean nacked = response.getAcks().stream().anyMatch(packet -> packet.getResponse() == Response.NACK);
         if (nacked) {
             addFailure(1, 3, "6.1.3.2.b - The request for DM5 was NACK'ed");
         }
 
-        Stream<DM5DiagnosticReadinessPacket> dm5Packets = packets.stream()
+        Stream<DM5DiagnosticReadinessPacket> dm5Packets = response.getPackets().stream()
                 .filter(p -> p instanceof DM5DiagnosticReadinessPacket)
-                .map(p -> (DM5DiagnosticReadinessPacket) p);
+                .map(p -> p);
 
         dm5Packets.filter(p -> p.isObd()).forEach(p -> {
             OBDModuleInformation info = new OBDModuleInformation(p.getSourceAddress());

--- a/src/org/etools/j1939_84/controllers/part1/Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step03Controller.java
@@ -65,10 +65,7 @@ public class Step03Controller extends StepController {
             addFailure(1, 3, "6.1.3.2.b - The request for DM5 was NACK'ed");
         }
 
-        Stream<DM5DiagnosticReadinessPacket> dm5Packets = response.getPackets().stream()
-                .filter(p -> p instanceof DM5DiagnosticReadinessPacket)
-                .map(p -> p);
-
+        Stream<DM5DiagnosticReadinessPacket> dm5Packets = response.getPackets().stream();
         dm5Packets.filter(p -> p.isObd()).forEach(p -> {
             OBDModuleInformation info = new OBDModuleInformation(p.getSourceAddress());
             info.setObdCompliance(p.getOBDCompliance());

--- a/src/org/etools/j1939_84/controllers/part1/Step04Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step04Controller.java
@@ -66,9 +66,7 @@ public class Step04Controller extends StepController {
 
         RequestResult<DM24SPNSupportPacket> result = obdTestsModule.requestDM24Packets(getListener(),
                 dataRepository.getObdModuleAddresses());
-        List<DM24SPNSupportPacket> globalPackets = result.getPackets().stream()
-                .filter(packet -> packet instanceof DM24SPNSupportPacket).map(p -> p)
-                .collect(Collectors.toList());
+        List<DM24SPNSupportPacket> globalPackets = result.getPackets();
 
         if (result.isRetryUsed()) {
             addFailure(1, 4, "6.1.4.2.a - Retry was required to obtain DM24 response");

--- a/src/org/etools/j1939_84/controllers/part1/Step04Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step04Controller.java
@@ -7,7 +7,6 @@ import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import org.etools.j1939_84.bus.j1939.packets.DM24SPNSupportPacket;
-import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.PartResultFactory;
@@ -22,7 +21,7 @@ import org.etools.j1939_84.modules.VehicleInformationModule;
 /**
  * @author Matt Gumbel (matt@soliddesign.net)
  *
- * The controller for DM24: SPN support
+ *         The controller for DM24: SPN support
  */
 public class Step04Controller extends StepController {
 
@@ -65,10 +64,10 @@ public class Step04Controller extends StepController {
     protected void run() throws Throwable {
         obdTestsModule.setJ1939(getJ1939());
 
-        RequestResult<ParsedPacket> result = obdTestsModule.requestDM24Packets(getListener(),
+        RequestResult<DM24SPNSupportPacket> result = obdTestsModule.requestDM24Packets(getListener(),
                 dataRepository.getObdModuleAddresses());
         List<DM24SPNSupportPacket> globalPackets = result.getPackets().stream()
-                .filter(packet -> packet instanceof DM24SPNSupportPacket).map(p -> (DM24SPNSupportPacket) p)
+                .filter(packet -> packet instanceof DM24SPNSupportPacket).map(p -> p)
                 .collect(Collectors.toList());
 
         if (result.isRetryUsed()) {

--- a/src/org/etools/j1939_84/controllers/part1/Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step07Controller.java
@@ -196,7 +196,7 @@ public class Step07Controller extends StepController {
 
             result.getPackets().stream()
                     .forEach(info -> {
-                        if (!Objects.equals(dm19.getCalibrationInformation(), info)) {
+                        if (!Objects.equals(dm19.getCalibrationInformation(), info.getCalibrationInformation())) {
                             getListener().addOutcome(1,
                                     7,
                                     Outcome.FAIL,

--- a/src/org/etools/j1939_84/controllers/part1/Step09Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step09Controller.java
@@ -23,8 +23,8 @@ import org.etools.j1939_84.utils.StringUtils;
 /**
  * @author Marianne Schaefer (marianne.m.schaefer@gmail.com)
  *
- * The controller for 6.1.9 Component ID: Make, Model, Serial Number
- * Support
+ *         The controller for 6.1.9 Component ID: Make, Model, Serial Number
+ *         Support
  */
 public class Step09Controller extends StepController {
 
@@ -66,14 +66,9 @@ public class Step09Controller extends StepController {
         // ComponentIdentificationPacket
         List<ComponentIdentificationPacket> packets = dataRepository.getObdModuleAddresses()
                 .stream()
-                .flatMap(moduleAddress -> {
-                    return getVehicleInformationModule().reportComponentIdentification(getListener(), moduleAddress)
-                            .stream();
-                })
-                .filter(packet -> {
-                    return packet instanceof ComponentIdentificationPacket;
-                })
-                .map(packet -> (ComponentIdentificationPacket) packet)
+                .flatMap(moduleAddress -> getVehicleInformationModule()
+                        .reportComponentIdentification(getListener(), moduleAddress)
+                        .stream())
                 .collect(Collectors.toList());
         if (packets.isEmpty()) {
             getListener().addOutcome(1,
@@ -82,7 +77,8 @@ public class Step09Controller extends StepController {
                     "6.1.9.1.a There are no positive responses (serial number SPN 588 not supported by any OBD ECU)");
         }
 
-        // Filter the modules responded to be only ones with function = 0 (engine
+        // Filter the modules responded to be only ones with function = 0
+        // (engine
         // function)
         List<OBDModuleInformation> zeroFunctionObdBDModules = dataRepository.getObdModules()
                 .stream()
@@ -101,9 +97,7 @@ public class Step09Controller extends StepController {
                 : zeroFunctionObdBDModules.get(0).getSourceAddress();
 
         List<ComponentIdentificationPacket> zeroFunctionPackets = packets.stream()
-                .filter(zeroPacket -> {
-                    return zeroPacket.getSourceAddress() == function0SourceAddress;
-                })
+                .filter(zeroPacket -> zeroPacket.getSourceAddress() == function0SourceAddress)
                 .collect(Collectors.toList());
 
         ComponentIdentificationPacket zeroFunctionPacket = null;
@@ -117,7 +111,8 @@ public class Step09Controller extends StepController {
         }
 
         // 6.1.9.2 Fail Criteria:
-        // c. Fail if the serial number field (SPN 588) from any function 0 device does
+        // c. Fail if the serial number field (SPN 588) from any function 0
+        // device does
         // not end in 6 numeric characters (ASCII 0 through ASCII 9).
         String serialNumber = zeroFunctionPacket != null ? zeroFunctionPacket.getSerialNumber() : "";
 
@@ -130,7 +125,8 @@ public class Step09Controller extends StepController {
                     "6.1.9.2.c Serial number field (SPN 588) from any function 0 device does not end in 6 numeric characters (ASCII 0 through ASCII 9)");
         }
 
-        // d. Fail if the make (SPN 586), model (SPN 587), or serial number (SPN 588)
+        // d. Fail if the make (SPN 586), model (SPN 587), or serial number (SPN
+        // 588)
         // from any OBD ECU contains any unprintable ASCII characters.
         String make = zeroFunctionPacket != null ? zeroFunctionPacket.getMake() : "";
         String model = zeroFunctionPacket != null ? zeroFunctionPacket.getModel() : null;
@@ -146,7 +142,8 @@ public class Step09Controller extends StepController {
         }
 
         // 6.1.9.3 Warn Criteria for OBD ECUs:
-        // a. Warn if the serial number field (SPN 588) from any function 0 device is
+        // a. Warn if the serial number field (SPN 588) from any function 0
+        // device is
         // less than 8 characters long.
         if (!serialNumber.isEmpty() && serialNumber.length() < 8) {
             getListener().addOutcome(1,
@@ -154,7 +151,8 @@ public class Step09Controller extends StepController {
                     Outcome.WARN,
                     "6.1.9.3.a Serial number field (SPN 588) from any function 0 device is less than 8 characters long");
         }
-        // b. Warn if the make field (SPN 586) is longer than 5 ASCII characters.
+        // b. Warn if the make field (SPN 586) is longer than 5 ASCII
+        // characters.
         if (!make.isEmpty() && make.length() > 5) {
             getListener().addOutcome(1,
                     9,
@@ -176,25 +174,28 @@ public class Step09Controller extends StepController {
                     "6.1.9.3.d Model field (SPN 587) is less than 1 character long");
         }
 
-        // 6.1.9.4 Actions2: [Note: No warning message shall be provided for responses
+        // 6.1.9.4 Actions2: [Note: No warning message shall be provided for
+        // responses
         // from non-OBD devices for PGN 59904].
 
-        // a. Global Component ID request (PGN 59904) for PGN 65259 (SPNs 586, 587, and
+        // a. Global Component ID request (PGN 59904) for PGN 65259 (SPNs 586,
+        // 587, and
         // 588).
         // b. Display each positive return in the log.
         List<ComponentIdentificationPacket> globalPackets = getVehicleInformationModule()
-                .reportComponentIdentification(getListener()).stream()
-                .filter(globalPacket -> globalPacket instanceof ComponentIdentificationPacket)
-                .collect(Collectors.toList());
+                .reportComponentIdentification(getListener());
 
         // 6.1.9.5 Fail Criteria2 for function 0:
 
-        // a. Fail if there is no positive response from function 0. (Global request not
+        // a. Fail if there is no positive response from function 0. (Global
+        // request not
         // supported or timed out)
-        // b. Fail if the global response does not match the destination specific
+        // b. Fail if the global response does not match the destination
+        // specific
         // response from function 0.
 
-        // FIXME This needs to check the packets to have source addresses from the
+        // FIXME This needs to check the packets to have source addresses from
+        // the
         // function=0 Module.
         List<OBDModuleInformation> globalObdModuleInformations = dataRepository.getObdModules().stream()
                 .filter(module -> module.getFunction() == 0).collect(Collectors.toList());
@@ -214,7 +215,8 @@ public class Step09Controller extends StepController {
         }
 
         // 6.1.9.6 Warn Criteria2 for OBD ECUs other than function 0:
-        // a. Warn if Component ID not supported for the global query in 6.1.9.4, when
+        // a. Warn if Component ID not supported for the global query in
+        // 6.1.9.4, when
         // supported by destination specific query
         packets.forEach(singlePacket -> {
             if (!globalPackets.contains(singlePacket)) {

--- a/src/org/etools/j1939_84/controllers/part1/Step10Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step10Controller.java
@@ -98,27 +98,16 @@ public class Step10Controller extends StepController {
         // is sent
         List<DM28PermanentEmissionDTCPacket> previousDM28Packets = dtcModule.requestDM28(getListener()).getPackets()
                 .stream()
-                .filter(packet -> packet instanceof DM28PermanentEmissionDTCPacket)
-                .map(p -> p)
                 .filter(t -> !t.getDtcs().isEmpty())
                 .collect(Collectors.toList());
 
         List<DM20MonitorPerformanceRatioPacket> previousDM20Packets = diagnosticReadinessModule
-                .requestDM20(getListener(), true).getPackets()
-                .stream()
-                .filter(packet -> packet instanceof DM20MonitorPerformanceRatioPacket)
-                .map(p -> p)
-                .collect(Collectors.toList());
+                .requestDM20(getListener(), true).getPackets();
 
-        List<DM33EmissionIncreasingAuxiliaryEmissionControlDeviceActiveTime> previousDM33Packets = new ArrayList<>();
-        obdModuleAddresses
-                .forEach(address -> {
-                    previousDM33Packets.addAll(dtcModule.requestDM33(getListener(), address).getPackets().stream()
-                            .filter(
-                                    packet -> packet instanceof DM33EmissionIncreasingAuxiliaryEmissionControlDeviceActiveTime)
-                            .map(p -> p)
-                            .collect(Collectors.toList()));
-                });
+        List<DM33EmissionIncreasingAuxiliaryEmissionControlDeviceActiveTime> previousDM33Packets = obdModuleAddresses
+                .stream()
+                .flatMap(address -> dtcModule.requestDM33(getListener(), address).getPackets().stream())
+                .collect(Collectors.toList());
 
         // 6.1.10 DM11: Diagnostic Data Clear/Reset for Active DTCs
         List<AcknowledgmentPacket> globalDM11Packets = dtcModule.requestDM11(getListener(), obdModuleAddresses)
@@ -130,8 +119,7 @@ public class Step10Controller extends StepController {
         // 6.1.10.2 Fail criteria:
         // a. Fail if NACK received from any HD OBD ECU.
         // from the dataRepo grab the obdModule addresses
-        boolean nacked = globalDM11Packets.stream().anyMatch(packet -> packet instanceof AcknowledgmentPacket
-                && packet.getResponse() == Response.NACK);
+        boolean nacked = globalDM11Packets.stream().anyMatch(packet -> packet.getResponse() == Response.NACK);
         if (nacked) {
             addWarning(1, 10, "6.1.10.3.a - The request for DM11 was ACK'ed");
         }
@@ -157,8 +145,7 @@ public class Step10Controller extends StepController {
 
         // 6.1.10.3 Warn criteria:
         // a. Warn if ACK received from any HD OBD ECU.16
-        boolean acked = globalDM11Packets.stream().anyMatch(packet -> packet instanceof AcknowledgmentPacket
-                && packet.getResponse() == Response.ACK);
+        boolean acked = globalDM11Packets.stream().anyMatch(packet -> packet.getResponse() == Response.ACK);
         if (acked) {
             addWarning(1, 10, "6.1.10.3.a - The request for DM11 was ACK'ed");
         }
@@ -174,8 +161,6 @@ public class Step10Controller extends StepController {
         List<DM6PendingEmissionDTCPacket> dm6Packets = dtcModule.requestDM6(getListener())
                 .getPackets()
                 .stream()
-                .filter(packet -> packet instanceof DM6PendingEmissionDTCPacket)
-                .map(p -> p)
                 .filter(t -> (!t.getDtcs().isEmpty()) ||
                         (t.getMalfunctionIndicatorLampStatus() != LampStatus.OFF &&
                                 t.getMalfunctionIndicatorLampStatus() != LampStatus.FAST_FLASH &&
@@ -197,8 +182,6 @@ public class Step10Controller extends StepController {
         List<DM12MILOnEmissionDTCPacket> dm12Packets = dtcModule.requestDM12(getListener())
                 .getPackets()
                 .stream()
-                .filter(packet -> packet instanceof DM12MILOnEmissionDTCPacket)
-                .map(p -> p)
                 .filter(t -> (!t.getDtcs().isEmpty()) ||
                         (t.getMalfunctionIndicatorLampStatus() != LampStatus.OFF &&
                                 t.getMalfunctionIndicatorLampStatus() != LampStatus.FAST_FLASH &&
@@ -221,8 +204,6 @@ public class Step10Controller extends StepController {
         // flashing
         List<DM23PreviouslyMILOnEmissionDTCPacket> dm23Packets = dtcModule.requestDM23(getListener()).getPackets()
                 .stream()
-                .filter(packet -> packet instanceof DM23PreviouslyMILOnEmissionDTCPacket)
-                .map(p -> p)
                 .filter(t -> (!t.getDtcs().isEmpty()) ||
                         (t.getMalfunctionIndicatorLampStatus() != LampStatus.OFF &&
                                 t.getMalfunctionIndicatorLampStatus() != LampStatus.FAST_FLASH &&
@@ -244,8 +225,6 @@ public class Step10Controller extends StepController {
         // previously
         // active DTCs
         List<DM29DtcCounts> dm29Packets = dtcModule.requestDM29(getListener()).getPackets().stream()
-                .filter(packet -> packet instanceof DM29DtcCounts)
-                .map(p -> p)
                 .filter(t -> t.getAllPendingDTCCount() != 0 ||
                         t.getEmissionRelatedMILOnDTCCount() != 0 ||
                         t.getEmissionRelatedPendingDTCCount() != 0 ||
@@ -270,8 +249,6 @@ public class Step10Controller extends StepController {
         List<DM5DiagnosticReadinessPacket> dm5Packets = diagnosticReadinessModule.requestDM5(getListener(), true)
                 .getPackets()
                 .stream()
-                .filter(packet -> packet instanceof DM5DiagnosticReadinessPacket)
-                .map(p -> p)
                 .filter(t -> (t.getActiveCodeCount() != 0) ||
                         (t.getPreviouslyActiveCodeCount() != 0))
                 .collect(Collectors.toList());
@@ -297,8 +274,6 @@ public class Step10Controller extends StepController {
         List<DM25ExpandedFreezeFrame> dm25Packets = dtcModule.requestDM25(getListener(), obdModuleAddresses)
                 .getPackets();
         List<DM25ExpandedFreezeFrame> dm25PacketsWithData = dm25Packets.stream()
-                .filter(packet -> packet instanceof DM25ExpandedFreezeFrame)
-                .map(p -> p)
                 .filter(t -> !t.getFreezeFrames().isEmpty())
                 .collect(Collectors.toList());
 
@@ -319,7 +294,6 @@ public class Step10Controller extends StepController {
         // supported. See
         // section 6 provisions before section 6.1).
         List<DM31ScaledTestResults> dm31Packets = dtcModule.requestDM31(getListener()).getPackets().stream()
-                .filter(packet -> packet instanceof DM31ScaledTestResults).map(p -> p)
                 .filter(t -> !t.getDtcLampStatuses().isEmpty())
                 .collect(Collectors.toList());
         if (!dm31Packets.isEmpty()) {
@@ -342,8 +316,6 @@ public class Step10Controller extends StepController {
         // and minutes run since code clear
         List<DM21DiagnosticReadinessPacket> dm21Packets = dtcModule.requestDM21(getListener()).getPackets()
                 .stream()
-                .filter(packet -> packet instanceof DM21DiagnosticReadinessPacket)
-                .map(p -> p)
                 .filter(packet -> packet.getKmWhileMILIsActivated() != 0 ||
                         packet.getMinutesWhileMILIsActivated() != 0 ||
                         packet.getKmSinceDTCsCleared() != 0 ||
@@ -388,8 +360,6 @@ public class Step10Controller extends StepController {
         // code clear
         List<DM26TripDiagnosticReadinessPacket> dm26Packets = dtcModule.requestDM26(getListener()).getPackets()
                 .stream()
-                .filter(packet -> packet instanceof DM26TripDiagnosticReadinessPacket)
-                .map(p -> p)
                 .filter(packet -> packet.getWarmUpsSinceClear() != 0)
                 .collect(Collectors.toList());
         if (!dm26Packets.isEmpty()) {
@@ -415,11 +385,7 @@ public class Step10Controller extends StepController {
             for (SupportedSPN supportedSPN : dataRepository.getObdModule(address).getSupportedSpns()) {
                 dm30Packets.addAll(
                         obdTestsModule.requestDM30Packets(getListener(), address, supportedSPN.getSpn())
-                                .getPackets()
-                                .stream()
-                                .filter(packet -> packet instanceof DM30ScaledTestResultsPacket)
-                                .map(p -> p)
-                                .collect(Collectors.toList()));
+                                .getPackets());
             }
         });
         dm30Packets.forEach(packet -> {
@@ -449,11 +415,7 @@ public class Step10Controller extends StepController {
         // monitor
         // specific denominators.
         List<DM20MonitorPerformanceRatioPacket> dm20Packets = diagnosticReadinessModule.requestDM20(getListener(), true)
-                .getPackets()
-                .stream()
-                .filter(packet -> packet instanceof DM20MonitorPerformanceRatioPacket)
-                .map(p -> p)
-                .collect(Collectors.toList());
+                .getPackets();
         dm20Packets.forEach(packet -> {
             boolean[] passedHere = { true };
             if (!previousDM20Packets.contains(packet)) {
@@ -494,8 +456,6 @@ public class Step10Controller extends StepController {
         // that was present before code clear.
         List<DM28PermanentEmissionDTCPacket> dm28Packets = dtcModule.requestDM28(getListener()).getPackets()
                 .stream()
-                .filter(packet -> packet instanceof DM28PermanentEmissionDTCPacket)
-                .map(p -> p)
                 .filter(t -> t.getDtcs().size() != 0)
                 .collect(Collectors.toList());
 
@@ -521,14 +481,9 @@ public class Step10Controller extends StepController {
         // a. DM33 EI-AECD information shall not be reset/cleared for any
         // non-zero
         // values present before code clear.
-        List<DM33EmissionIncreasingAuxiliaryEmissionControlDeviceActiveTime> dm33Packets = new ArrayList<>();
-        obdModuleAddresses
-                .forEach(address -> {
-                    dm33Packets.addAll(dtcModule.requestDM33(getListener(), address).getPackets().stream().filter(
-                            packet -> packet instanceof DM33EmissionIncreasingAuxiliaryEmissionControlDeviceActiveTime)
-                            .map(p -> p)
-                            .collect(Collectors.toList()));
-                });
+        List<DM33EmissionIncreasingAuxiliaryEmissionControlDeviceActiveTime> dm33Packets = obdModuleAddresses.stream()
+                .flatMap(address -> dtcModule.requestDM33(getListener(), address).getPackets().stream())
+                .collect(Collectors.toList());
         if (!previousDM33Packets.retainAll(dm33Packets)) {
             StringBuilder failureMessage = new StringBuilder(
                     "Pre DTC all clear code sent retrieved the DM33 packet : ");

--- a/src/org/etools/j1939_84/controllers/part1/Step11Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step11Controller.java
@@ -69,10 +69,7 @@ public class Step11Controller extends StepController {
         // a. Global DM21 (send Request (PGN 59904) for PGN 49408 (SPNs 3069,
         // 3294-3296)).
         List<DM21DiagnosticReadinessPacket> globalDm21Packets = diagnosticReadinessModule
-                .requestDM21Packets(getListener(), true).getPackets().stream()
-                .filter(packet -> packet instanceof DM21DiagnosticReadinessPacket)
-                .map(p -> p)
-                .collect(Collectors.toList());
+                .requestDM21Packets(getListener(), true).getPackets();
 
         // 6.1.11.2 Fail criteria:
         globalDm21Packets.forEach(packet -> {

--- a/src/org/etools/j1939_84/controllers/part1/Step11Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step11Controller.java
@@ -9,12 +9,11 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
-import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response;
 import org.etools.j1939_84.bus.j1939.packets.DM21DiagnosticReadinessPacket;
-import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.PartResultFactory;
+import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
 import org.etools.j1939_84.modules.DiagnosticReadinessModule;
@@ -25,7 +24,7 @@ import org.etools.j1939_84.modules.VehicleInformationModule;
  *
  * @author Marianne Schaefer (marianne.m.schaefer@gmail.com)
  *
- * The controller for 6.1.11 DM21: Diagnostic readiness 2
+ *         The controller for 6.1.11 DM21: Diagnostic readiness 2
  */
 
 public class Step11Controller extends StepController {
@@ -72,12 +71,13 @@ public class Step11Controller extends StepController {
         List<DM21DiagnosticReadinessPacket> globalDm21Packets = diagnosticReadinessModule
                 .requestDM21Packets(getListener(), true).getPackets().stream()
                 .filter(packet -> packet instanceof DM21DiagnosticReadinessPacket)
-                .map(p -> (DM21DiagnosticReadinessPacket) p)
+                .map(p -> p)
                 .collect(Collectors.toList());
 
         // 6.1.11.2 Fail criteria:
         globalDm21Packets.forEach(packet -> {
-            // a. Fail if any ECU reports distance with MIL on (SPN 3069) is not zero.
+            // a. Fail if any ECU reports distance with MIL on (SPN 3069) is not
+            // zero.
             if (packet.getKmSinceDTCsCleared() != 0 || packet.getMilesSinceDTCsCleared() != 0) {
                 addFailure(1,
                         11,
@@ -89,14 +89,16 @@ public class Step11Controller extends StepController {
                         11,
                         "6.1.11.1.b - Fail if any ECU reports distance SCC (SPN 3294) is not zero");
             }
-            // c. Fail if any ECU reports time with MIL on (SPN 3295) is not zero (if
+            // c. Fail if any ECU reports time with MIL on (SPN 3295) is not
+            // zero (if
             // supported).17
             if (packet.getMinutesWhileMILIsActivated() != 0) {
                 addFailure(1,
                         11,
                         "6.1.11.1.c - Fail if any ECU reports time with MIL on (SPN 3295) is not zero (if supported)");
             }
-            // d. Fail if any ECU reports time SCC (SPN 3296) > 1 minute (if supported).
+            // d. Fail if any ECU reports time SCC (SPN 3296) > 1 minute (if
+            // supported).
             if (packet.getMinutesSinceDTCsCleared() > 1) {
                 addFailure(1,
                         11,
@@ -110,39 +112,40 @@ public class Step11Controller extends StepController {
 
         // 6.1.11.3 Actions2:
         // a. DS DM21 to each OBD ECU
-        List<ParsedPacket> addressSpecificDM21Results = new ArrayList<>();
-        dataRepository.getObdModuleAddresses().forEach(address -> {
-            addressSpecificDM21Results
-                    .addAll(diagnosticReadinessModule.getDM21Packets(getListener(), true, address).getPackets());
-        });
-        List<DM21DiagnosticReadinessPacket> addressSpecificDm21Packets = addressSpecificDM21Results.stream()
-                .filter(p -> p instanceof DM21DiagnosticReadinessPacket)
-                .map(p -> (DM21DiagnosticReadinessPacket) p)
+        List<RequestResult<DM21DiagnosticReadinessPacket>> addressSpecificDM21Results = dataRepository
+                .getObdModuleAddresses().stream()
+                .map(addr -> diagnosticReadinessModule.getDM21Packets(getListener(), true, addr))
                 .collect(Collectors.toList());
 
         // 6.1.11.4 Fail criteria2:
+        List<DM21DiagnosticReadinessPacket> addressSpecificDm21Packets = addressSpecificDM21Results.stream()
+                .flatMap(r -> r.getPackets().stream()).collect(Collectors.toList());
         addressSpecificDm21Packets
                 .forEach(packet -> {
-                    // a. Fail if any ECU reports distance with MIL on (SPN 3069) is not zero.
+                    // a. Fail if any ECU reports distance with MIL on (SPN
+                    // 3069) is not zero.
                     if (packet.getKmSinceDTCsCleared() != 0 || packet.getMilesSinceDTCsCleared() != 0) {
                         addFailure(1,
                                 11,
                                 "6.1.11.4.a - Fail if any ECU reports distance with MIL on (SPN 3069) is not zero");
                     }
-                    // b. Fail if any ECU reports distance SCC (SPN 3294) is not zero.
+                    // b. Fail if any ECU reports distance SCC (SPN 3294) is not
+                    // zero.
                     if (packet.getKmWhileMILIsActivated() != 0 || packet.getMilesWhileMILIsActivated() != 0) {
                         addFailure(1,
                                 11,
                                 "6.1.11.4.b. Fail if any ECU reports distance SCC (SPN 3294) is not zero");
                     }
-                    // c. Fail if any ECU reports time with MIL on (SPN 3295) is not zero (if
+                    // c. Fail if any ECU reports time with MIL on (SPN 3295) is
+                    // not zero (if
                     // supported)
                     if (packet.getMinutesWhileMILIsActivated() != 0) {
                         addFailure(1,
                                 11,
                                 "6.1.11.4.c - Fail if any ECU reports time with MIL on (SPN 3295) is not zero (if supported)");
                     }
-                    // d. Fail if any ECU reports time SCC (SPN 3296) > 1 minute (if supported).
+                    // d. Fail if any ECU reports time SCC (SPN 3296) > 1 minute
+                    // (if supported).
                     if (packet.getMinutesSinceDTCsCleared() != 0) {
                         addFailure(1,
                                 11,
@@ -167,16 +170,14 @@ public class Step11Controller extends StepController {
                     "6.1.11.4.e - Fail if any responses differ from global responses");
         }
 
-        // f. Fail if NACK not received from OBD ECUs that did not respond to global
+        // f. Fail if NACK not received from OBD ECUs that did not respond to
+        // global
         // query.
         addressSpecificDm21Packets.forEach(addressPacket -> globalDm21Packets
                 .removeIf(globalPacket -> globalPacket.getSourceAddress() == addressPacket.getSourceAddress()));
 
-        addressSpecificDM21Results
-                .stream()
-                .filter(packet -> packet instanceof AcknowledgmentPacket)
-                .map(p -> (AcknowledgmentPacket) p)
-                .filter(p -> p.getResponse() == Response.NACK)
+        addressSpecificDM21Results.stream().flatMap(e -> e.getAcks().stream())
+                .filter(a -> a.getResponse() == Response.NACK)
                 .forEach(nackPacket -> globalDm21Packets
                         .removeIf(globalPacket -> globalPacket.getSourceAddress() == nackPacket.getSourceAddress()));
 

--- a/src/org/etools/j1939_84/controllers/part1/Step16Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step16Controller.java
@@ -10,7 +10,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
-import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response;
 import org.etools.j1939_84.bus.j1939.packets.DM2PreviouslyActiveDTC;
 import org.etools.j1939_84.bus.j1939.packets.LampStatus;
@@ -98,12 +97,13 @@ public class Step16Controller extends StepController {
         // a. Global DM2 (send Request (PGN 59904) for PGN 65227 (SPNs
         // 1213-1215, 3038,
         // 1706)).
-        RequestResult<ParsedPacket> globalDiagnosticTroubleCodePackets = dtcModule.requestDM2(getListener(), true);
+        RequestResult<DM2PreviouslyActiveDTC> globalDiagnosticTroubleCodePackets = dtcModule.requestDM2(getListener(),
+                true);
 
         // Get DM2PrevisoulyActiveDTC so we can get DTCs and report accordingly
         List<DM2PreviouslyActiveDTC> globalDM2s = globalDiagnosticTroubleCodePackets.getPackets().stream()
                 .filter(p -> p instanceof DM2PreviouslyActiveDTC)
-                .map(p -> (DM2PreviouslyActiveDTC) p)
+                .map(p -> p)
                 .collect(Collectors.toList());
 
         // 6.1.16.2.a Fail if any OBD ECU reports a previously active DTC.
@@ -140,11 +140,11 @@ public class Step16Controller extends StepController {
         }
 
         // 6.1.16.3.a DS DM2 to each OBD ECU
-        List<ParsedPacket> dsDM2s = new ArrayList<>();
+        List<DM2PreviouslyActiveDTC> dsDM2s = new ArrayList<>();
         obdModuleAddresses.stream()
                 .forEach(address -> dsDM2s.addAll(dtcModule.requestDM2(getListener(), true, address).getPackets()));
 
-        List<ParsedPacket> unmatchedPackets = globalDiagnosticTroubleCodePackets.getPackets().stream()
+        List<DM2PreviouslyActiveDTC> unmatchedPackets = globalDiagnosticTroubleCodePackets.getPackets().stream()
                 .filter(aObject -> (!verifyPacketsEquality(dsDM2s, aObject))).collect(Collectors.toList());
 
         // 6.1.16.4.a Fail if any responses differ from global responses
@@ -158,9 +158,8 @@ public class Step16Controller extends StepController {
         // 6.1.16.4.b Fail if NACK not received from OBD ECUs that did not
         // respond to
         // global query
-        boolean missingNack = unmatchedPackets.stream()
-                .anyMatch(packet -> packet instanceof AcknowledgmentPacket
-                        && ((AcknowledgmentPacket) packet).getResponse() != Response.NACK);
+        boolean missingNack = globalDiagnosticTroubleCodePackets.getAcks().stream()
+                .anyMatch(packet -> packet.getResponse() != Response.NACK);
         if (missingNack) {
             getListener().addOutcome(1,
                     16,
@@ -169,7 +168,7 @@ public class Step16Controller extends StepController {
         }
     }
 
-    private boolean verifyPacketsEquality(List<ParsedPacket> packets, ParsedPacket packet) {
+    private boolean verifyPacketsEquality(List<? extends ParsedPacket> packets, ParsedPacket packet) {
         boolean found = false;
         for (ParsedPacket p : packets) {
             if (p.getSourceAddress() == packet.getSourceAddress() &&

--- a/src/org/etools/j1939_84/controllers/part1/Step16Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step16Controller.java
@@ -101,10 +101,7 @@ public class Step16Controller extends StepController {
                 true);
 
         // Get DM2PrevisoulyActiveDTC so we can get DTCs and report accordingly
-        List<DM2PreviouslyActiveDTC> globalDM2s = globalDiagnosticTroubleCodePackets.getPackets().stream()
-                .filter(p -> p instanceof DM2PreviouslyActiveDTC)
-                .map(p -> p)
-                .collect(Collectors.toList());
+        List<DM2PreviouslyActiveDTC> globalDM2s = globalDiagnosticTroubleCodePackets.getPackets();
 
         // 6.1.16.2.a Fail if any OBD ECU reports a previously active DTC.
         if (globalDM2s.stream().flatMap(packet -> packet.getDtcs().stream()).findAny().isPresent()) {

--- a/src/org/etools/j1939_84/model/RequestResult.java
+++ b/src/org/etools/j1939_84/model/RequestResult.java
@@ -4,24 +4,55 @@
 package org.etools.j1939_84.model;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.etools.j1939_84.bus.Either;
+import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
+import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 
 /**
  * @author Matt Gumbel (matt@soliddesign.net)
  *
  */
-public class RequestResult<T> {
+public class RequestResult<T extends ParsedPacket> {
+
+    private final List<AcknowledgmentPacket> acks;
 
     private final List<T> packets;
+
     private final boolean retryUsed;
 
+    public RequestResult(boolean retryUsed,
+            List<Either<T, AcknowledgmentPacket>> packets) {
+        this(retryUsed,
+                packets.stream().flatMap(e -> e.left.stream()).collect(Collectors.toList()),
+                packets.stream().flatMap(e -> e.right.stream()).collect(Collectors.toList()));
+    }
+
     /**
-     * @param retryUsed boolean representation of retry used
-     * @param packets   list of packets to be included in the requestResult
+     * @param retryUsed
+     *            boolean representation of retry used
+     * @param packets
+     *            list of packets to be included in the requestResult
      *
      */
-    public RequestResult(boolean retryUsed, List<T> packets) {
+    public RequestResult(boolean retryUsed, List<T> packets, List<AcknowledgmentPacket> acks) {
         this.retryUsed = retryUsed;
-        this.packets = packets;
+        this.packets = Objects.requireNonNull(packets);
+        this.acks = Objects.requireNonNull(acks);
+    }
+
+    public List<AcknowledgmentPacket> getAcks() {
+        return acks;
+    }
+
+    public List<Either<T, AcknowledgmentPacket>> getEither() {
+        return Stream
+                .concat(packets.stream().map(p -> new Either<>(p, (AcknowledgmentPacket) null)),
+                        acks.stream().map(a -> new Either<>((T) null, a)))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/org/etools/j1939_84/modules/DiagnosticReadinessModule.java
+++ b/src/org/etools/j1939_84/modules/DiagnosticReadinessModule.java
@@ -672,18 +672,12 @@ public class DiagnosticReadinessModule extends FunctionalModule {
                 listener,
                 fullString)
                         // FIXME this ignores NACKs
-                        .getPackets().stream()
-                        .filter(packet -> packet instanceof DM5DiagnosticReadinessPacket)
-                        .map(p -> p)
-                        .collect(Collectors.toList());
+                        .getPackets();
 
         if (!parsedPackets.isEmpty()) {
             listener.onResult("");
             listener.onResult("Vehicle Composite of DM5:");
-            List<CompositeMonitoredSystem> systems = getCompositeSystems(parsedPackets.stream()
-                    .filter(packet -> packet instanceof DM5DiagnosticReadinessPacket)
-                    .map(p -> p).collect(Collectors.toList()),
-                    true);
+            List<CompositeMonitoredSystem> systems = getCompositeSystems(parsedPackets, true);
             listener.onResult(systems.stream().map(t -> t.toString()).collect(Collectors.toList()));
         }
         return new RequestResult<>(false, parsedPackets, Collections.emptyList());

--- a/src/org/etools/j1939_84/modules/DiagnosticReadinessModule.java
+++ b/src/org/etools/j1939_84/modules/DiagnosticReadinessModule.java
@@ -206,12 +206,11 @@ public class DiagnosticReadinessModule extends FunctionalModule {
      */
     public List<DM20MonitorPerformanceRatioPacket> getDM20Packets(ResultsListener listener,
             boolean fullString) {
-        List<ParsedPacket> packets = getPacketsFromGlobal("Global DM20 Request",
+        return getPacketsFromGlobal("Global DM20 Request",
                 DM20MonitorPerformanceRatioPacket.PGN,
                 DM20MonitorPerformanceRatioPacket.class,
                 listener,
                 fullString).getPackets();
-        return filterPackets(packets, DM20MonitorPerformanceRatioPacket.class);
     }
 
     /**
@@ -228,7 +227,7 @@ public class DiagnosticReadinessModule extends FunctionalModule {
      *            sent
      * @return the {@link List} of {@link DM21DiagnosticReadinessPacket}s
      */
-    public RequestResult<ParsedPacket> getDM21Packets(ResultsListener listener,
+    public RequestResult<DM21DiagnosticReadinessPacket> getDM21Packets(ResultsListener listener,
             boolean fullString,
             int obdModuleAddress) {
 
@@ -254,13 +253,11 @@ public class DiagnosticReadinessModule extends FunctionalModule {
     public List<DM26TripDiagnosticReadinessPacket> getDM26Packets(ResultsListener listener,
             boolean fullString) {
 
-        List<ParsedPacket> packets = getPacketsFromGlobal("Global DM26 Request",
+        return getPacketsFromGlobal("Global DM26 Request",
                 DM26TripDiagnosticReadinessPacket.PGN,
                 DM26TripDiagnosticReadinessPacket.class,
                 listener,
                 fullString).getPackets();
-
-        return filterPackets(packets, DM26TripDiagnosticReadinessPacket.class);
 
     }
 
@@ -277,13 +274,11 @@ public class DiagnosticReadinessModule extends FunctionalModule {
      */
     public List<DM5DiagnosticReadinessPacket> getDM5Packets(ResultsListener listener, boolean fullString) {
 
-        List<ParsedPacket> packets = getPacketsFromGlobal("Global DM5 Request",
+        return getPacketsFromGlobal("Global DM5 Request",
                 DM5DiagnosticReadinessPacket.PGN,
                 DM5DiagnosticReadinessPacket.class,
                 listener,
                 fullString).getPackets();
-
-        return filterPackets(packets, DM5DiagnosticReadinessPacket.class);
     }
 
     /**
@@ -609,7 +604,7 @@ public class DiagnosticReadinessModule extends FunctionalModule {
      *            false to only include the returned raw packet in the report
      * @return the {@link List} of {@link DM20MonitorPerformanceRatioPacket}s
      */
-    public RequestResult<ParsedPacket> requestDM20(ResultsListener listener,
+    public RequestResult<DM20MonitorPerformanceRatioPacket> requestDM20(ResultsListener listener,
             boolean fullString) {
         return getPacketsFromGlobal("Global DM20 Request",
                 DM20MonitorPerformanceRatioPacket.PGN,
@@ -629,7 +624,7 @@ public class DiagnosticReadinessModule extends FunctionalModule {
      *            false to only include the returned raw packet in the report
      * @return the {@link List} of {@link DM21DiagnosticReadinessPacket}s
      */
-    public RequestResult<ParsedPacket> requestDM21Packets(ResultsListener listener,
+    public RequestResult<DM21DiagnosticReadinessPacket> requestDM21Packets(ResultsListener listener,
             boolean fullString) {
         return getPacketsFromGlobal("Global DM21 Request",
                 DM21DiagnosticReadinessPacket.PGN,
@@ -649,7 +644,7 @@ public class DiagnosticReadinessModule extends FunctionalModule {
      *            false to only include the returned raw packet in the report
      * @return the {@link List} of {@link DM5DiagnosticReadinessPacket}s
      */
-    public RequestResult<ParsedPacket> requestDM5(ResultsListener listener,
+    public RequestResult<DM5DiagnosticReadinessPacket> requestDM5(ResultsListener listener,
             boolean fullString) {
 
         return getPacketsFromGlobal("Global DM5 Request",
@@ -670,14 +665,16 @@ public class DiagnosticReadinessModule extends FunctionalModule {
      *            false to only include the returned raw packet in the report
      * @return the {@link List} of {@link DM5DiagnosticReadinessPacket}s
      */
-    public RequestResult<ParsedPacket> requestDM5Packets(ResultsListener listener, boolean fullString) {
-        List<ParsedPacket> parsedPackets = getPacketsFromGlobal("Global DM5 Request",
+    public RequestResult<DM5DiagnosticReadinessPacket> requestDM5Packets(ResultsListener listener, boolean fullString) {
+        List<DM5DiagnosticReadinessPacket> parsedPackets = getPacketsFromGlobal("Global DM5 Request",
                 DM5DiagnosticReadinessPacket.PGN,
                 DM5DiagnosticReadinessPacket.class,
                 listener,
-                fullString).getPackets().stream()
+                fullString)
+                        // FIXME this ignores NACKs
+                        .getPackets().stream()
                         .filter(packet -> packet instanceof DM5DiagnosticReadinessPacket)
-                        .map(p -> (DM5DiagnosticReadinessPacket) p)
+                        .map(p -> p)
                         .collect(Collectors.toList());
 
         if (!parsedPackets.isEmpty()) {
@@ -685,11 +682,11 @@ public class DiagnosticReadinessModule extends FunctionalModule {
             listener.onResult("Vehicle Composite of DM5:");
             List<CompositeMonitoredSystem> systems = getCompositeSystems(parsedPackets.stream()
                     .filter(packet -> packet instanceof DM5DiagnosticReadinessPacket)
-                    .map(p -> (DM5DiagnosticReadinessPacket) p).collect(Collectors.toList()),
+                    .map(p -> p).collect(Collectors.toList()),
                     true);
             listener.onResult(systems.stream().map(t -> t.toString()).collect(Collectors.toList()));
         }
-        return new RequestResult<>(false, parsedPackets);
+        return new RequestResult<>(false, parsedPackets, Collections.emptyList());
     }
 
     private String rowForDM20(int sourceLength,

--- a/src/org/etools/j1939_84/modules/EngineSpeedModule.java
+++ b/src/org/etools/j1939_84/modules/EngineSpeedModule.java
@@ -24,7 +24,9 @@ public class EngineSpeedModule extends FunctionalModule {
     private EngineSpeedPacket getEngineSpeedPacket() {
         // The transmission rate changes based upon the engine speed. 100 ms is
         // the longest period between messages when the engine is off
-        return getJ1939().read(EngineSpeedPacket.class, J1939.ENGINE_ADDR, 300, TimeUnit.MILLISECONDS).orElse(null);
+        return getJ1939().read(EngineSpeedPacket.class, J1939.ENGINE_ADDR, 300, TimeUnit.MILLISECONDS)
+                .flatMap(e -> e.left)
+                .orElse(null);
     }
 
     /**

--- a/src/org/etools/j1939_84/modules/VehicleInformationModule.java
+++ b/src/org/etools/j1939_84/modules/VehicleInformationModule.java
@@ -290,7 +290,7 @@ public class VehicleInformationModule extends FunctionalModule {
                 ComponentIdentificationPacket.class,
                 listener,
                 false,
-                address).getPackets().stream().map(p -> p).collect(Collectors.toList());
+                address).getPackets();
     }
 
     /**


### PR DESCRIPTION
This changes the way the stream of parsed packets is handled.  It was a Stream<ParsedPackets>, but now it a Stream<Either<T extends ParsedPacket,AcknowledgmentPacket>>.  Previously the stream had to be filtered and checked for ACKs in the modules and controllers, but now they are stored separately.  The BusResult has a Either<T,AcknowledgmentPacket>. RequestResult has a list of T and a list of AcknowledgmentPacket.  It makes it much easier to manipulate and removes error prone "instanceof" in filters all over the place.

In the process I found very questionable logic in Step 16 tests and one bug in Step 9 (the old stream would include ACKs that did not apply to the request).  There are a lot of places where NACKs are just ignored (but matching the requirements); I put in FIXMEs in those places.

I did not correct the bugs in Step16.  I want to talk about it at our next meeting.

DM6 tests are incomplete; they appear to be a copy of DM11, but should look more like DM2.