### PR TITLE
Update DTCModule/DTCModuleTest for DM25 messaging

### DIFF
--- a/src-test/org/etools/j1939_84/modules/DTCModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/DTCModuleTest.java
@@ -1606,12 +1606,12 @@ public class DTCModuleTest {
                 Packet.create(0xE800, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xF9, 0xD3, 0xFE, 0x00));
 
         when(j1939.requestPacket(requestPacket,
-                DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+                DM25ExpandedFreezeFrame.class, 0x00, 3,
                 TimeUnit.SECONDS.toMillis(15)))
                         .thenReturn(Optional.of(new BusResult<>(false,
                                 new Either<DM25ExpandedFreezeFrame, AcknowledgmentPacket>(null, packet1))));
 
-        String expected = "10:15:30.000 Direct DM25 Request to Engine #1 (0)" + NL;
+        String expected = "10:15:30.000 Destination Specific DM25 Request to Engine #1 (0)" + NL;
         expected += "10:15:30.000 18EA00A5 B7 FD 00 (TX)" + NL;
         expected += "10:15:30.000 18E80000 01 FF FF FF F9 D3 FE 00" + NL;
         expected += "Acknowledgment from Engine #1 (0): Response: NACK, Group Function: 255, Address Acknowledged: 249, PGN Requested: 65235"
@@ -1625,7 +1625,7 @@ public class DTCModuleTest {
         assertEquals(expected, listener.getResults());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
-        verify(j1939).requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+        verify(j1939).requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, 0x00, 3,
                 TimeUnit.SECONDS.toMillis(15));
     }
 
@@ -1636,10 +1636,10 @@ public class DTCModuleTest {
         when(j1939.createRequestPacket(pgn, 0x00)).thenReturn(requestPacket);
 
         when(j1939.requestPacket(requestPacket,
-                DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+                DM25ExpandedFreezeFrame.class, 0x00, 3,
                 TimeUnit.SECONDS.toMillis(15)))
                         .thenReturn(Optional.empty());
-        String expected = "10:15:30.000 Direct DM25 Request to Engine #1 (0)" + NL;
+        String expected = "10:15:30.000 Destination Specific DM25 Request to Engine #1 (0)" + NL;
         expected += "10:15:30.000 18EA00A5 B7 FD 00 (TX)" + NL;
         expected += "Error: Timeout - No Response." + NL;
 
@@ -1651,7 +1651,7 @@ public class DTCModuleTest {
         assertEquals(expected, listener.getResults());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
-        verify(j1939).requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+        verify(j1939).requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, 0x00, 3,
                 TimeUnit.SECONDS.toMillis(15));
     }
 
@@ -1751,11 +1751,11 @@ public class DTCModuleTest {
                 0xFA };
 
         DM25ExpandedFreezeFrame packet = new DM25ExpandedFreezeFrame(Packet.create(pgn, 0x00, realData));
-        when(j1939.requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+        when(j1939.requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, 0x00, 3,
                 TimeUnit.SECONDS.toMillis(15)))
                         .thenReturn(Optional.of(new BusResult<>(false, packet)));
 
-        String expected = "10:15:30.000 Direct DM25 Request to Engine #1 (0)" + NL;
+        String expected = "10:15:30.000 Destination Specific DM25 Request to Engine #1 (0)" + NL;
         expected += "10:15:30.000 18EA00A5 B7 FD 00 (TX)" + NL;
         expected += "10:15:30.000 18FDB700 56 9D 00 07 7F 00 01 7B 00 00 39 3A 5C 0F C4 FB 00 00 00 F1 26 00 00 00 12 7A 7D 80 65 00 00 32 00 00 00 00 84 AD 00 39 2C 30 39 FC 38 C6 35 E0 34 2C 2F 00 00 7D 7D 8A 28 A0 0F A0 0F D1 37 00 CA 28 01 A4 0D 00 A8 C3 B2 C2 C3 00 00 00 00 7E D0 07 00 7D 04 FF FA"
                 + NL;
@@ -1775,7 +1775,7 @@ public class DTCModuleTest {
         assertEquals(expected, listener.getResults());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
-        verify(j1939).requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+        verify(j1939).requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, 0x00, 3,
                 TimeUnit.SECONDS.toMillis(15));
     }
 
@@ -1789,7 +1789,7 @@ public class DTCModuleTest {
                 Packet.create(0xE800, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xF9, 0xD3, 0xFE, 0x00));
 
         when(j1939.requestPacket(requestPacket,
-                DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+                DM25ExpandedFreezeFrame.class, GLOBAL_ADDR, 3,
                 TimeUnit.SECONDS.toMillis(15)))
                         .thenReturn(Optional.of(new BusResult<>(false,
                                 new Either<DM25ExpandedFreezeFrame, AcknowledgmentPacket>(null, packet1))));
@@ -1808,7 +1808,7 @@ public class DTCModuleTest {
         assertEquals(expected, listener.getResults());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
-        verify(j1939).requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+        verify(j1939).requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, GLOBAL_ADDR, 3,
                 TimeUnit.SECONDS.toMillis(15));
     }
 
@@ -1832,7 +1832,7 @@ public class DTCModuleTest {
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).requestPacket(requestPacket,
-                DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+                DM25ExpandedFreezeFrame.class, GLOBAL_ADDR, 3,
                 TimeUnit.SECONDS.toMillis(15));
 
     }
@@ -1933,7 +1933,7 @@ public class DTCModuleTest {
                 0xFA };
 
         DM25ExpandedFreezeFrame packet = new DM25ExpandedFreezeFrame(Packet.create(pgn, 0x00, realData));
-        when(j1939.requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+        when(j1939.requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, GLOBAL_ADDR, 3,
                 TimeUnit.SECONDS.toMillis(15)))
                         .thenReturn(Optional.of(new BusResult<>(false, packet)));
 
@@ -1957,7 +1957,7 @@ public class DTCModuleTest {
         assertEquals(expected, listener.getResults());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
-        verify(j1939).requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+        verify(j1939).requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, GLOBAL_ADDR, 3,
                 TimeUnit.SECONDS.toMillis(15));
     }
 

--- a/src-test/org/etools/j1939_84/modules/DTCModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/DTCModuleTest.java
@@ -16,16 +16,19 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.etools.j1939_84.bus.Either;
 import org.etools.j1939_84.bus.Packet;
+import org.etools.j1939_84.bus.j1939.BusResult;
 import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM11ClearActiveDTCsPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM12MILOnEmissionDTCPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM23PreviouslyMILOnEmissionDTCPacket;
+import org.etools.j1939_84.bus.j1939.packets.DM25ExpandedFreezeFrame;
 import org.etools.j1939_84.bus.j1939.packets.DM28PermanentEmissionDTCPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM2PreviouslyActiveDTC;
 import org.etools.j1939_84.bus.j1939.packets.DM33EmissionIncreasingAuxiliaryEmissionControlDeviceActiveTime;
@@ -1575,8 +1578,6 @@ public class DTCModuleTest {
         Packet requestPacket = Packet.create(0xEA00 | 0xFF, BUS_ADDR, true, pgn, pgn >> 8, pgn >> 16);
         when(j1939.createRequestPacket(pgn, 0xFF)).thenReturn(requestPacket);
 
-        Packet packet = Packet.create(0, 0, 0x55, 0x55, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF);
-        new DM6PendingEmissionDTCPacket(packet);
         when(j1939.requestRaw(DM6PendingEmissionDTCPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS))
                 .thenReturn(Stream.empty());
 
@@ -1594,4 +1595,370 @@ public class DTCModuleTest {
         verify(j1939).createRequestPacket(pgn, 0xFF);
         verify(j1939).requestRaw(DM6PendingEmissionDTCPacket.class, requestPacket, 5500, TimeUnit.MILLISECONDS);
     }
+
+    @Test
+    public void testResquestDM25DestinationSpecificNackOnly() {
+        final int pgn = DM25ExpandedFreezeFrame.PGN;
+        Packet requestPacket = Packet.create(0xEA00 | 0x00, BUS_ADDR, true, pgn, pgn >> 8, pgn >> 16);
+        when(j1939.createRequestPacket(pgn, 0x00)).thenReturn(requestPacket);
+
+        AcknowledgmentPacket packet1 = new AcknowledgmentPacket(
+                Packet.create(0xE800, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xF9, 0xD3, 0xFE, 0x00));
+
+        when(j1939.requestPacket(requestPacket,
+                DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+                TimeUnit.SECONDS.toMillis(15)))
+                        .thenReturn(Optional.of(new BusResult<>(false,
+                                new Either<DM25ExpandedFreezeFrame, AcknowledgmentPacket>(null, packet1))));
+
+        String expected = "10:15:30.000 Direct DM25 Request to Engine #1 (0)" + NL;
+        expected += "10:15:30.000 18EA00A5 B7 FD 00 (TX)" + NL;
+        expected += "10:15:30.000 18E80000 01 FF FF FF F9 D3 FE 00" + NL;
+        expected += "Acknowledgment from Engine #1 (0): Response: NACK, Group Function: 255, Address Acknowledged: 249, PGN Requested: 65235"
+                + NL;
+
+        TestResultsListener listener = new TestResultsListener();
+        RequestResult<DM25ExpandedFreezeFrame> expectedResult = new RequestResult<>(false,
+                Collections.emptyList(),
+                Collections.singletonList(packet1));
+        assertEquals(expectedResult, instance.requestDM25(listener, 0x00));
+        assertEquals(expected, listener.getResults());
+
+        verify(j1939).createRequestPacket(pgn, 0x00);
+        verify(j1939).requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+                TimeUnit.SECONDS.toMillis(15));
+    }
+
+    @Test
+    public void testResquestDM25DestinationSpecificNoResponse() {
+        final int pgn = DM25ExpandedFreezeFrame.PGN;
+        Packet requestPacket = Packet.create(0xEA00 | 0x00, BUS_ADDR, true, pgn, pgn >> 8, pgn >> 16);
+        when(j1939.createRequestPacket(pgn, 0x00)).thenReturn(requestPacket);
+
+        when(j1939.requestPacket(requestPacket,
+                DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+                TimeUnit.SECONDS.toMillis(15)))
+                        .thenReturn(Optional.empty());
+        String expected = "10:15:30.000 Direct DM25 Request to Engine #1 (0)" + NL;
+        expected += "10:15:30.000 18EA00A5 B7 FD 00 (TX)" + NL;
+        expected += "Error: Timeout - No Response." + NL;
+
+        TestResultsListener listener = new TestResultsListener();
+        RequestResult<DM25ExpandedFreezeFrame> expectedResult = new RequestResult<>(false,
+                Collections.emptyList(),
+                Collections.emptyList());
+        assertEquals(expectedResult, instance.requestDM25(listener, 0x00));
+        assertEquals(expected, listener.getResults());
+
+        verify(j1939).createRequestPacket(pgn, 0x00);
+        verify(j1939).requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+                TimeUnit.SECONDS.toMillis(15));
+    }
+
+    @Test
+    public void testResquestDM25DestinationSpecificWithResponse() {
+        final int pgn = DM25ExpandedFreezeFrame.PGN;
+        Packet requestPacket = Packet.create(0xEA00 | 0x00, BUS_ADDR, true, pgn, pgn >> 8, pgn >> 16);
+        when(j1939.createRequestPacket(pgn, 0x00)).thenReturn(requestPacket);
+
+        int[] realData = new int[] {
+                0x56,
+                0x9D,
+                0x00,
+                0x07,
+                0x7F,
+                0x00,
+                0x01,
+                0x7B,
+                0x00,
+                0x00,
+                0x39,
+                0x3A,
+                0x5C,
+                0x0F,
+                0xC4,
+                0xFB,
+                0x00,
+                0x00,
+                0x00,
+                0xF1,
+                0x26,
+                0x00,
+                0x00,
+                0x00,
+                0x12,
+                0x7A,
+                0x7D,
+                0x80,
+                0x65,
+                0x00,
+                0x00,
+                0x32,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x84,
+                0xAD,
+                0x00,
+                0x39,
+                0x2C,
+                0x30,
+                0x39,
+                0xFC,
+                0x38,
+                0xC6,
+                0x35,
+                0xE0,
+                0x34,
+                0x2C,
+                0x2F,
+                0x00,
+                0x00,
+                0x7D,
+                0x7D,
+                0x8A,
+                0x28,
+                0xA0,
+                0x0F,
+                0xA0,
+                0x0F,
+                0xD1,
+                0x37,
+                0x00,
+                0xCA,
+                0x28,
+                0x01,
+                0xA4,
+                0x0D,
+                0x00,
+                0xA8,
+                0xC3,
+                0xB2,
+                0xC2,
+                0xC3,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x7E,
+                0xD0,
+                0x07,
+                0x00,
+                0x7D,
+                0x04,
+                0xFF,
+                0xFA };
+
+        DM25ExpandedFreezeFrame packet = new DM25ExpandedFreezeFrame(Packet.create(pgn, 0x00, realData));
+        when(j1939.requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+                TimeUnit.SECONDS.toMillis(15)))
+                        .thenReturn(Optional.of(new BusResult<>(false, packet)));
+
+        String expected = "10:15:30.000 Direct DM25 Request to Engine #1 (0)" + NL;
+        expected += "10:15:30.000 18EA00A5 B7 FD 00 (TX)" + NL;
+        expected += "10:15:30.000 18FDB700 56 9D 00 07 7F 00 01 7B 00 00 39 3A 5C 0F C4 FB 00 00 00 F1 26 00 00 00 12 7A 7D 80 65 00 00 32 00 00 00 00 84 AD 00 39 2C 30 39 FC 38 C6 35 E0 34 2C 2F 00 00 7D 7D 8A 28 A0 0F A0 0F D1 37 00 CA 28 01 A4 0D 00 A8 C3 B2 C2 C3 00 00 00 00 7E D0 07 00 7D 04 FF FA"
+                + NL;
+        expected += "DM25 from Engine #1 (0): " + NL;
+        expected += "Freeze Frames: [" + NL;
+        expected += "DTC: Engine Fuel 1 Injector Metering Rail 1 Pressure (157) Mechanical System Not Responding Or Out Of Adjustment (7) 127 times"
+                + NL;
+        expected += "SPN Data: 00 01 7B 00 00 39 3A 5C 0F C4 FB 00 00 00 F1 26 00 00 00 12 7A 7D 80 65 00 00 32 00 00 00 00 84 AD 00 39 2C 30 39 FC 38 C6 35 E0 34 2C 2F 00 00 7D 7D 8A 28 A0 0F A0 0F D1 37 00 CA 28 01 A4 0D 00 A8 C3 B2 C2 C3 00 00 00 00 7E D0 07 00 7D 04 FF"
+                + NL;
+        expected += "]" + NL;
+
+        TestResultsListener listener = new TestResultsListener();
+        RequestResult<DM25ExpandedFreezeFrame> expectedResult = new RequestResult<>(false,
+                Collections.singletonList(packet),
+                Collections.emptyList());
+        assertEquals(expectedResult, instance.requestDM25(listener, 0x00));
+        assertEquals(expected, listener.getResults());
+
+        verify(j1939).createRequestPacket(pgn, 0x00);
+        verify(j1939).requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+                TimeUnit.SECONDS.toMillis(15));
+    }
+
+    @Test
+    public void testResquestDM25GlobalNackOnly() {
+        final int pgn = DM25ExpandedFreezeFrame.PGN;
+        Packet requestPacket = Packet.create(0xEA00 | GLOBAL_ADDR, BUS_ADDR, true, pgn, pgn >> 8, pgn >> 16);
+        when(j1939.createRequestPacket(pgn, GLOBAL_ADDR)).thenReturn(requestPacket);
+
+        AcknowledgmentPacket packet1 = new AcknowledgmentPacket(
+                Packet.create(0xE800, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xF9, 0xD3, 0xFE, 0x00));
+
+        when(j1939.requestPacket(requestPacket,
+                DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+                TimeUnit.SECONDS.toMillis(15)))
+                        .thenReturn(Optional.of(new BusResult<>(false,
+                                new Either<DM25ExpandedFreezeFrame, AcknowledgmentPacket>(null, packet1))));
+
+        String expected = "10:15:30.000 Global DM25 Request to Global (255)" + NL;
+        expected += "10:15:30.000 18EAFFA5 B7 FD 00 (TX)" + NL;
+        expected += "10:15:30.000 18E80000 01 FF FF FF F9 D3 FE 00" + NL;
+        expected += "Acknowledgment from Engine #1 (0): Response: NACK, Group Function: 255, Address Acknowledged: 249, PGN Requested: 65235"
+                + NL;
+
+        TestResultsListener listener = new TestResultsListener();
+        RequestResult<DM25ExpandedFreezeFrame> expectedResult = new RequestResult<>(false,
+                Collections.emptyList(),
+                Collections.singletonList(packet1));
+        assertEquals(expectedResult, instance.requestDM25(listener));
+        assertEquals(expected, listener.getResults());
+
+        verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
+        verify(j1939).requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+                TimeUnit.SECONDS.toMillis(15));
+    }
+
+    @Test
+    public void testResquestDM25GlobalNoResponse() {
+        final int pgn = DM25ExpandedFreezeFrame.PGN;
+        Packet requestPacket = Packet.create(0xEA00 | GLOBAL_ADDR, BUS_ADDR, true, pgn, pgn >> 8, pgn >> 16);
+        when(j1939.createRequestPacket(pgn, GLOBAL_ADDR)).thenReturn(requestPacket);
+
+        String expected = "10:15:30.000 Global DM25 Request to Global (255)" + NL;
+        expected += "10:15:30.000 18EAFFA5 B7 FD 00 (TX)" + NL;
+        expected += "Error: Timeout - No Response."
+                + NL;
+
+        TestResultsListener listener = new TestResultsListener();
+        RequestResult<DM25ExpandedFreezeFrame> expectedResult = new RequestResult<>(false,
+                Collections.emptyList(),
+                Collections.emptyList());
+        assertEquals(expectedResult, instance.requestDM25(listener));
+        assertEquals(expected, listener.getResults());
+
+        verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
+        verify(j1939).requestPacket(requestPacket,
+                DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+                TimeUnit.SECONDS.toMillis(15));
+
+    }
+
+    @Test
+    public void testResquestDM25GlobalWithResponse() {
+        final int pgn = DM25ExpandedFreezeFrame.PGN;
+        Packet requestPacket = Packet.create(0xEA00 | GLOBAL_ADDR, BUS_ADDR, true, pgn, pgn >> 8, pgn >> 16);
+        when(j1939.createRequestPacket(pgn, GLOBAL_ADDR)).thenReturn(requestPacket);
+
+        int[] realData = new int[] {
+                0x56,
+                0x9D,
+                0x00,
+                0x07,
+                0x7F,
+                0x00,
+                0x01,
+                0x7B,
+                0x00,
+                0x00,
+                0x39,
+                0x3A,
+                0x5C,
+                0x0F,
+                0xC4,
+                0xFB,
+                0x00,
+                0x00,
+                0x00,
+                0xF1,
+                0x26,
+                0x00,
+                0x00,
+                0x00,
+                0x12,
+                0x7A,
+                0x7D,
+                0x80,
+                0x65,
+                0x00,
+                0x00,
+                0x32,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x84,
+                0xAD,
+                0x00,
+                0x39,
+                0x2C,
+                0x30,
+                0x39,
+                0xFC,
+                0x38,
+                0xC6,
+                0x35,
+                0xE0,
+                0x34,
+                0x2C,
+                0x2F,
+                0x00,
+                0x00,
+                0x7D,
+                0x7D,
+                0x8A,
+                0x28,
+                0xA0,
+                0x0F,
+                0xA0,
+                0x0F,
+                0xD1,
+                0x37,
+                0x00,
+                0xCA,
+                0x28,
+                0x01,
+                0xA4,
+                0x0D,
+                0x00,
+                0xA8,
+                0xC3,
+                0xB2,
+                0xC2,
+                0xC3,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x7E,
+                0xD0,
+                0x07,
+                0x00,
+                0x7D,
+                0x04,
+                0xFF,
+                0xFA };
+
+        DM25ExpandedFreezeFrame packet = new DM25ExpandedFreezeFrame(Packet.create(pgn, 0x00, realData));
+        when(j1939.requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+                TimeUnit.SECONDS.toMillis(15)))
+                        .thenReturn(Optional.of(new BusResult<>(false, packet)));
+
+        String expected = "10:15:30.000 Global DM25 Request to Global (255)" + NL;
+        expected += "10:15:30.000 18EAFFA5 B7 FD 00 (TX)" + NL;
+        expected += "10:15:30.000 18FDB700 56 9D 00 07 7F 00 01 7B 00 00 39 3A 5C 0F C4 FB 00 00 00 F1 26 00 00 00 12 7A 7D 80 65 00 00 32 00 00 00 00 84 AD 00 39 2C 30 39 FC 38 C6 35 E0 34 2C 2F 00 00 7D 7D 8A 28 A0 0F A0 0F D1 37 00 CA 28 01 A4 0D 00 A8 C3 B2 C2 C3 00 00 00 00 7E D0 07 00 7D 04 FF FA"
+                + NL;
+        expected += "DM25 from Engine #1 (0): " + NL;
+        expected += "Freeze Frames: [" + NL;
+        expected += "DTC: Engine Fuel 1 Injector Metering Rail 1 Pressure (157) Mechanical System Not Responding Or Out Of Adjustment (7) 127 times"
+                + NL;
+        expected += "SPN Data: 00 01 7B 00 00 39 3A 5C 0F C4 FB 00 00 00 F1 26 00 00 00 12 7A 7D 80 65 00 00 32 00 00 00 00 84 AD 00 39 2C 30 39 FC 38 C6 35 E0 34 2C 2F 00 00 7D 7D 8A 28 A0 0F A0 0F D1 37 00 CA 28 01 A4 0D 00 A8 C3 B2 C2 C3 00 00 00 00 7E D0 07 00 7D 04 FF"
+                + NL;
+        expected += "]" + NL;
+
+        TestResultsListener listener = new TestResultsListener();
+        RequestResult<DM25ExpandedFreezeFrame> expectedResult = new RequestResult<>(false,
+                Collections.singletonList(packet),
+                Collections.emptyList());
+        assertEquals(expectedResult, instance.requestDM25(listener));
+        assertEquals(expected, listener.getResults());
+
+        verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
+        verify(j1939).requestPacket(requestPacket, DM25ExpandedFreezeFrame.class, requestPacket.getSource(), 3,
+                TimeUnit.SECONDS.toMillis(15));
+    }
+
 }

--- a/src/org/etools/j1939_84/bus/j1939/packets/DM25ExpandedFreezeFrame.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/DM25ExpandedFreezeFrame.java
@@ -12,8 +12,7 @@ import java.util.List;
 import org.etools.j1939_84.bus.Packet;
 
 /**
- * The {@link ParsedPacket} for Expanded Freeze Frame
- * Codes (DM25)
+ * The {@link ParsedPacket} for Expanded Freeze Frame Codes (DM25)
  *
  * @author Marianne Schaefer (marianne.m.schaefer@gmail.com)
  *

--- a/src/org/etools/j1939_84/modules/DTCModule.java
+++ b/src/org/etools/j1939_84/modules/DTCModule.java
@@ -306,12 +306,8 @@ public class DTCModule extends FunctionalModule {
      * @return {@link List} of {@link DM25ExpandedFreezeFrame}s
      */
     public <T extends ParsedPacket> RequestResult<DM25ExpandedFreezeFrame> requestDM25(ResultsListener listener) {
+        return requestDM25(listener, GLOBAL_ADDR);
 
-        Packet request = getJ1939().createRequestPacket(DM25ExpandedFreezeFrame.PGN, GLOBAL_ADDR);
-
-        listener.onResult(getTime() + " Global DM25 Request to " + Lookup.getAddressName(GLOBAL_ADDR));
-        listener.onResult(getTime() + " " + request.toString());
-        return requestDM25(listener, request);
     }
 
     /**
@@ -327,33 +323,19 @@ public class DTCModule extends FunctionalModule {
             int obdModuleAddress) {
 
         Packet request = getJ1939().createRequestPacket(DM25ExpandedFreezeFrame.PGN, obdModuleAddress);
-        listener.onResult(getTime() + " Direct DM25 Request to " + Lookup.getAddressName(obdModuleAddress));
+
+        String message = obdModuleAddress == GLOBAL_ADDR ? " Global DM25 Request to "
+                : " Destination Specific DM25 Request to ";
+        listener.onResult(getTime() + message + Lookup.getAddressName(obdModuleAddress));
         listener.onResult(getTime() + " " + request.toString());
-
-        return requestDM25(listener, request);
-    }
-
-    /**
-     * Helper method that does the work for DM25's
-     *
-     * Sends a request to the vehicle for {@link DM25ExpandedFreezeFrame}s
-     *
-     * @param listener
-     *            the {@link ResultsListener}
-     * @param obdModuleAddresses
-     *            {@link Collection} of Integers}
-     * @return {@link List} of {@link DM25ExpandedFreezeFrame}s
-     */
-    private <T extends ParsedPacket> RequestResult<DM25ExpandedFreezeFrame> requestDM25(ResultsListener listener,
-            Packet requestPacket) {
 
         List<Either<DM25ExpandedFreezeFrame, AcknowledgmentPacket>> packets = new ArrayList<>();
         boolean retryUsed = false;
 
         BusResult<DM25ExpandedFreezeFrame> result = getJ1939()
-                .requestPacket(requestPacket,
+                .requestPacket(request,
                         DM25ExpandedFreezeFrame.class,
-                        requestPacket.getSource(),
+                        request.getSource(),
                         3,
                         TimeUnit.SECONDS.toMillis(15))
                 .orElse(null);

--- a/src/org/etools/j1939_84/modules/DTCModule.java
+++ b/src/org/etools/j1939_84/modules/DTCModule.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import org.etools.j1939_84.bus.Either;
 import org.etools.j1939_84.bus.Packet;
+import org.etools.j1939_84.bus.j1939.BusResult;
 import org.etools.j1939_84.bus.j1939.Lookup;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response;
@@ -304,31 +305,13 @@ public class DTCModule extends FunctionalModule {
      *            {@link Collection} of Integers}
      * @return {@link List} of {@link DM25ExpandedFreezeFrame}s
      */
-    public RequestResult<DM25ExpandedFreezeFrame> requestDM25(ResultsListener listener,
-            Collection<Integer> obdModuleAddresses) {
-        List<Either<DM25ExpandedFreezeFrame, AcknowledgmentPacket>> packets = new ArrayList<>();
-        boolean retryUsed = false;
+    public <T extends ParsedPacket> RequestResult<DM25ExpandedFreezeFrame> requestDM25(ResultsListener listener) {
 
-        for (int address : obdModuleAddresses) {
-            Packet request = getJ1939().createRequestPacket(DM25ExpandedFreezeFrame.PGN, address);
-            listener.onResult(getTime() + " Direct DM25 Request to " + Lookup.getAddressName(address));
-            listener.onResult(getTime() + " " + request.toString());
-            DM25ExpandedFreezeFrame packet = getJ1939()
-                    .requestPacket(request, DM25ExpandedFreezeFrame.class, address, 3, TimeUnit.SECONDS.toMillis(15))
-                    .flatMap(br -> br.getPacket().left)
-                    .orElse(null);
-            if (packet == null) {
-                listener.onResult(TIMEOUT_MESSAGE);
-            } else {
-                listener.onResult(
-                        packet.getPacket().toString(getDateTimeModule().getTimeFormatter()));
-                listener.onResult(packet.toString());
-                // FIXME this drops NACKs
-                packets.add(new Either<>(packet, null));
-            }
-            listener.onResult("");
-        }
-        return new RequestResult<>(retryUsed, packets);
+        Packet request = getJ1939().createRequestPacket(DM25ExpandedFreezeFrame.PGN, GLOBAL_ADDR);
+
+        listener.onResult(getTime() + " Global DM25 Request to " + Lookup.getAddressName(GLOBAL_ADDR));
+        listener.onResult(getTime() + " " + request.toString());
+        return requestDM25(listener, request);
     }
 
     /**
@@ -340,32 +323,57 @@ public class DTCModule extends FunctionalModule {
      *            {@link Collection} of Integers}
      * @return {@link List} of {@link DM25ExpandedFreezeFrame}s
      */
-    public RequestResult<DM25ExpandedFreezeFrame> requestDM25(ResultsListener listener,
+    public <T extends ParsedPacket> RequestResult<DM25ExpandedFreezeFrame> requestDM25(ResultsListener listener,
             int obdModuleAddress) {
-        List<Either<DM25ExpandedFreezeFrame, AcknowledgmentPacket>> packets = new ArrayList<>();
-        boolean retryUsed = false;
 
         Packet request = getJ1939().createRequestPacket(DM25ExpandedFreezeFrame.PGN, obdModuleAddress);
         listener.onResult(getTime() + " Direct DM25 Request to " + Lookup.getAddressName(obdModuleAddress));
         listener.onResult(getTime() + " " + request.toString());
-        DM25ExpandedFreezeFrame packet = getJ1939()
-                .requestPacket(request,
+
+        return requestDM25(listener, request);
+    }
+
+    /**
+     * Helper method that does the work for DM25's
+     *
+     * Sends a request to the vehicle for {@link DM25ExpandedFreezeFrame}s
+     *
+     * @param listener
+     *            the {@link ResultsListener}
+     * @param obdModuleAddresses
+     *            {@link Collection} of Integers}
+     * @return {@link List} of {@link DM25ExpandedFreezeFrame}s
+     */
+    private <T extends ParsedPacket> RequestResult<DM25ExpandedFreezeFrame> requestDM25(ResultsListener listener,
+            Packet requestPacket) {
+
+        List<Either<DM25ExpandedFreezeFrame, AcknowledgmentPacket>> packets = new ArrayList<>();
+        boolean retryUsed = false;
+
+        BusResult<DM25ExpandedFreezeFrame> result = getJ1939()
+                .requestPacket(requestPacket,
                         DM25ExpandedFreezeFrame.class,
-                        obdModuleAddress,
+                        requestPacket.getSource(),
                         3,
                         TimeUnit.SECONDS.toMillis(15))
-                .flatMap(br -> br.getPacket().left)
                 .orElse(null);
+
+        ParsedPacket packet = null;
+        if (result != null) {
+            Either<DM25ExpandedFreezeFrame, AcknowledgmentPacket> either = result.getPacket();
+            packets.add(either);
+            packet = either.left.orElse(null);
+            if (packet == null) {
+                packet = either.right.orElse(null);
+            }
+        }
+
         if (packet == null) {
             listener.onResult(TIMEOUT_MESSAGE);
         } else {
-            listener.onResult(
-                    packet.getPacket().toString(getDateTimeModule().getTimeFormatter()));
+            listener.onResult(packet.getPacket().toString(getDateTimeModule().getTimeFormatter()));
             listener.onResult(packet.toString());
-            // FIXME this logic just drops NACKS
-            packets.add(new Either<>(packet, null));
         }
-        listener.onResult("");
         return new RequestResult<>(retryUsed, packets);
     }
 

--- a/src/org/etools/j1939_84/modules/DTCModule.java
+++ b/src/org/etools/j1939_84/modules/DTCModule.java
@@ -315,18 +315,18 @@ public class DTCModule extends FunctionalModule {
      *
      * @param listener
      *            the {@link ResultsListener}
-     * @param obdModuleAddresses
-     *            {@link Collection} of Integers}
+     * @param moduleAddress
+     *            the address to send the request to
      * @return {@link List} of {@link DM25ExpandedFreezeFrame}s
      */
     public <T extends ParsedPacket> RequestResult<DM25ExpandedFreezeFrame> requestDM25(ResultsListener listener,
-            int obdModuleAddress) {
+            int moduleAddress) {
 
-        Packet request = getJ1939().createRequestPacket(DM25ExpandedFreezeFrame.PGN, obdModuleAddress);
+        Packet request = getJ1939().createRequestPacket(DM25ExpandedFreezeFrame.PGN, moduleAddress);
 
-        String message = obdModuleAddress == GLOBAL_ADDR ? " Global DM25 Request to "
+        String message = moduleAddress == GLOBAL_ADDR ? " Global DM25 Request to "
                 : " Destination Specific DM25 Request to ";
-        listener.onResult(getTime() + message + Lookup.getAddressName(obdModuleAddress));
+        listener.onResult(getTime() + message + Lookup.getAddressName(moduleAddress));
         listener.onResult(getTime() + " " + request.toString());
 
         List<Either<DM25ExpandedFreezeFrame, AcknowledgmentPacket>> packets = new ArrayList<>();
@@ -335,7 +335,7 @@ public class DTCModule extends FunctionalModule {
         BusResult<DM25ExpandedFreezeFrame> result = getJ1939()
                 .requestPacket(request,
                         DM25ExpandedFreezeFrame.class,
-                        request.getSource(),
+                        moduleAddress,
                         3,
                         TimeUnit.SECONDS.toMillis(15))
                 .orElse(null);


### PR DESCRIPTION
Fix #79 Update DM25 to conform to new RequestResults object and combine/clean up duplicated code.