### PR TITLE
Update DTCModuleTest for DM29

### DIFF
--- a/src-test/org/etools/j1939_84/bus/j1939/packets/DM29DtcCountsTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/packets/DM29DtcCountsTest.java
@@ -120,11 +120,11 @@ public class DM29DtcCountsTest {
     @Test
     public void testToString() {
         String expected = "DM29 from Engine #1 (0): " + NL;
-        expected += "Emission-Related Pending DTC Count                                                   9" + NL;
-        expected += "All Pending DTC Count                                                               32" + NL;
-        expected += "Emission-Related MIL-On DTC Count                                                   71" + NL;
-        expected += "Emission-Related Previously MIL-On DTC Count                                        49" + NL;
-        expected += "Emission-Related Permanent DTC Count                                                 1" + NL;
+        expected += "Emission-Related Pending DTC Count                               9" + NL;
+        expected += "All Pending DTC Count                                           32" + NL;
+        expected += "Emission-Related MIL-On DTC Count                               71" + NL;
+        expected += "Emission-Related Previously MIL-On DTC Count                    49" + NL;
+        expected += "Emission-Related Permanent DTC Count                             1";
         assertEquals(expected, instance.toString());
     }
 

--- a/src/org/etools/j1939_84/bus/j1939/packets/DM29DtcCounts.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/DM29DtcCounts.java
@@ -10,13 +10,12 @@ import java.util.Arrays;
 import org.etools.j1939_84.bus.Packet;
 
 /**
- * The {@link ParsedPacket} for Diagnostic Trouble Code Counts
- * Codes (DM29)
+ * The {@link ParsedPacket} for Diagnostic Trouble Code Counts Codes (DM29)
  *
  * @author Marianne Schaefer (marianne.m.schaefer@gmail.com)
  *
- * This DM conveys the number of regulated DTC counts (Pending, Permanent, MIL-
- * On, PMIL-On)
+ *         This DM conveys the number of regulated DTC counts (Pending,
+ *         Permanent, MIL- On, PMIL-On)
  */
 public class DM29DtcCounts extends ParsedPacket {
     // Hex value of PGN = 009E00
@@ -105,21 +104,20 @@ public class DM29DtcCounts extends ParsedPacket {
         StringBuilder sb = new StringBuilder();
         sb.append(getStringPrefix() + NL);
         sb.append(String
-                .format("%1$-65s %2$20d", "Emission-Related Pending DTC Count", getEmissionRelatedPendingDTCCount()))
+                .format("%1$-45s %2$20d", "Emission-Related Pending DTC Count", getEmissionRelatedPendingDTCCount()))
                 .append(NL);
-        sb.append(String.format("%1$-65s %2$20d", "All Pending DTC Count", getAllPendingDTCCount()))
+        sb.append(String.format("%1$-45s %2$20d", "All Pending DTC Count", getAllPendingDTCCount()))
                 .append(NL);
         sb.append(String
-                .format("%1$-65s %2$20d", "Emission-Related MIL-On DTC Count", getEmissionRelatedMILOnDTCCount()))
+                .format("%1$-45s %2$20d", "Emission-Related MIL-On DTC Count", getEmissionRelatedMILOnDTCCount()))
                 .append(NL);
-        sb.append(String.format("%1$-65s %2$20d",
+        sb.append(String.format("%1$-45s %2$20d",
                 "Emission-Related Previously MIL-On DTC Count",
                 getEmissionRelatedPreviouslyMILOnDTCCount()))
                 .append(NL);
-        sb.append(String.format("%1$-65s %2$20d",
+        sb.append(String.format("%1$-45s %2$20d",
                 "Emission-Related Permanent DTC Count",
-                getEmissionRelatedPermanentDTCCount()))
-                .append(NL);
+                getEmissionRelatedPermanentDTCCount()));
         return sb.toString();
     }
 }


### PR DESCRIPTION
Fix #78 Update DTCModuleTest to add testing for DM29s.  Also, fixed the toString() method in the DM29 object and update its test.