### PR TITLE
Update DTCLampStatus to parse lamp statuses correctly

### DIFF
--- a/src-test/org/etools/j1939_84/bus/j1939/packets/DTCLampStatusTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/packets/DTCLampStatusTest.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright 2020 Equipment & Tool Institute
+ */
+package org.etools.j1939_84.bus.j1939.packets;
+
+import static org.etools.j1939_84.J1939_84.NL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.etools.j1939_84.bus.Packet;
+import org.junit.Test;
+
+/**
+ * Unit tests the {@link DTCLampStatus} class
+ *
+ * @author Marianne Schaefer (marianne.m.schaefer@gmail.com)
+ */
+public class DTCLampStatusTest {
+
+    /**
+     * Test method for
+     * {@link org.etools.j1939_84.bus.j1939.packets.DTCLampStatus#getData()}. *
+     * {@link org.etools.j1939_84.bus.j1939.packets.DTCLampStatus#getRedStopLampStatus()}.
+     */
+    @Test
+    public void testDTCLampsAllOther() {
+        int[] data = new int[] { 0xEE, // SPN least significant bit
+                0x10, // SPN most significant bit
+                0x04, // Failure mode indicator
+                0x00, // SPN Conversion Occurrence Count
+                0xAA, // Lamp Status/Support
+                0x55 };// Lamp Status/State
+        DTCLampStatus instance = new DTCLampStatus(data);
+        assertEquals(LampStatus.OTHER, instance.getAmberWarningLampStatus());
+        assertEquals(LampStatus.OTHER, instance.getMalfunctionIndicatorLampStatus());
+        assertEquals(LampStatus.OTHER, instance.getRedStopLampStatus());
+        assertEquals(LampStatus.OTHER, instance.getProtectLampStatus());
+    }
+
+    /**
+     * Test method for
+     * {@link org.etools.j1939_84.bus.j1939.packets.DTCLampStatus#DTCLampStatus(int[])}.
+     * {@link org.etools.j1939_84.bus.j1939.packets.DTCLampStatus#getProtectLampStatus()}.
+     * {@link org.etools.j1939_84.bus.j1939.packets.DTCLampStatus#getRedStopLampStatus()}.
+     * {@link org.etools.j1939_84.bus.j1939.packets.DTCLampStatus#getMalfunctionIndicatorLampStatus()}.
+     */
+    @Test
+    public void testDTCLampStatus() {
+        int[] data = new int[] { 0x61, // SPN least significant bit
+                0x02, // SPN most significant bit
+                0x13, // Failure mode indicator
+                0x81, // SPN Conversion Occurrence Count
+                0x62, // Lamp Status/Support
+                0x1D };// Lamp Status/State
+        DTCLampStatus instance = new DTCLampStatus(data);
+        assertEquals(LampStatus.OFF, instance.getAmberWarningLampStatus());
+        assertEquals(LampStatus.SLOW_FLASH, instance.getMalfunctionIndicatorLampStatus());
+        assertEquals(LampStatus.OTHER, instance.getRedStopLampStatus());
+        assertEquals(LampStatus.OTHER, instance.getProtectLampStatus());
+    }
+
+    @Test
+    public void testDTCLampStatusAllOff() {
+        int[] data = new int[] { 0x61, // SPN least significant bit
+                0x02, // SPN most significant bit
+                0x13, // Failure mode indicator
+                0x81, // SPN Conversion Occurrence Count
+                0x00, // Lamp Status/Support
+                0xFF };// Lamp Status/State
+        DTCLampStatus instance = new DTCLampStatus(data);
+        assertEquals(LampStatus.OFF, instance.getAmberWarningLampStatus());
+        assertEquals(LampStatus.OFF, instance.getMalfunctionIndicatorLampStatus());
+        assertEquals(LampStatus.OFF, instance.getRedStopLampStatus());
+        assertEquals(LampStatus.OFF, instance.getProtectLampStatus());
+    }
+
+    @Test
+    public void testDTCLampStatusAllSlowFlash() {
+        int[] data = new int[] { 0xEE, // SPN least significant bit
+                0x10, // SPN most significant bit
+                0x04, // Failure mode indicator
+                0x00, // SPN Conversion Occurrence Count
+                0x55, // Lamp Status/Support
+                0x00 };// Lamp Status/State
+        DTCLampStatus instance = new DTCLampStatus(data);
+        assertEquals(LampStatus.SLOW_FLASH, instance.getAmberWarningLampStatus());
+        assertEquals(LampStatus.SLOW_FLASH, instance.getMalfunctionIndicatorLampStatus());
+        assertEquals(LampStatus.SLOW_FLASH, instance.getRedStopLampStatus());
+        assertEquals(LampStatus.SLOW_FLASH, instance.getProtectLampStatus());
+    }
+
+    /**
+     * Test method for
+     * {@link org.etools.j1939_84.bus.j1939.packets.DTCLampStatus#equals()}.
+     */
+    @Test
+    public void testEquals() {
+
+        DTCLampStatus instance = new DTCLampStatus(new int[] {
+                0x61, // SPN least significant bit
+                0x02, // SPN most significant bit
+                0x13, // Failure mode indicator
+                0x81, // SPN Conversion Occurrence Count
+                0x00, // Lamp Status/Support
+                0xFF });// Lamp Status/State
+        DTCLampStatus instance2 = new DTCLampStatus(new int[] {
+                0x61, // SPN least significant bit
+                0x02, // SPN most significant bit
+                0x13, // Failure mode indicator
+                0x81, // SPN Conversion Occurrence Count
+                0x00, // Lamp Status/Support
+                0xFF });// Lamp Status/State
+        DTCLampStatus instance3 = new DTCLampStatus(new int[] {
+                0x61, // SPN least significant bit
+                0x02, // SPN most significant bit
+                0x13, // Failure mode indicator
+                0x81, // SPN Conversion Occurrence Count
+                0xAA, // Lamp Status/Support
+                0x55 });// Lamp Status/State
+        DiagnosticTroubleCodePacket instance4 = new DiagnosticTroubleCodePacket(Packet.create(0, 0x00,
+                0x61, // SPN least significant bit
+                0x02, // SPN most significant bit
+                0x13, // Failure mode indicator
+                0x81, // SPN Conversion Occurrence Count
+                0xAA, // Lamp Status/Support
+                0x55));
+        assertEquals(true, instance.equals(instance2));
+        assertEquals(false, instance.equals(instance3));
+        assertEquals(false, instance.equals(instance4));
+    }
+
+    /**
+     * Test method for
+     * {@link org.etools.j1939_84.bus.j1939.packets.DTCLampStatus#getDtc()}.
+     */
+    @Test
+    public void testGetDtcs() {
+        int[] data = new int[] { 0x61, // SPN least significant bit
+                0x02, // SPN most significant bit
+                0x13, // Failure mode indicator
+                0x81, // SPN Conversion Occurrence Count
+                0x00, // Lamp Status/Support
+                0xFF };// Lamp Status/State
+        DTCLampStatus instance = new DTCLampStatus(data);
+        DiagnosticTroubleCode expected = new DiagnosticTroubleCode(new int[] { 0x61, 0x02, 0x13, 0x81 });
+        assertEquals(expected, instance.getDtcs());
+    }
+
+    /**
+     * Test method for
+     * {@link org.etools.j1939_84.bus.j1939.packets.DTCLampStatus#hashCode()}.
+     */
+    @Test
+    public void testHashCode() {
+        DTCLampStatus instance = new DTCLampStatus(new int[] {
+                0x61, // SPN least significant bit
+                0x02, // SPN most significant bit
+                0x13, // Failure mode indicator
+                0x81, // SPN Conversion Occurrence Count
+                0x00, // Lamp Status/Support
+                0xFF });// Lamp Status/State
+        DTCLampStatus instance2 = new DTCLampStatus(new int[] {
+                0x61, // SPN least significant bit
+                0x02, // SPN most significant bit
+                0x13, // Failure mode indicator
+                0x81, // SPN Conversion Occurrence Count
+                0x00, // Lamp Status/Support
+                0xFF });// Lamp Status/State
+        assertTrue(instance.hashCode() == instance2.hashCode());
+    }
+
+    /**
+     * Test method for
+     * {@link org.etools.j1939_84.bus.j1939.packets.DTCLampStatus#toString()}.
+     */
+    @Test
+    public void testToString() {
+        int[] data = new int[] { 0x00, 0x00, 0x00, 0x00, 0x62, 0x1D };
+        DTCLampStatus instance = new DTCLampStatus(data);
+        String expected = "MIL: slow flash, RSL: other, AWL: off, PL: other" + NL;
+        expected += "DTC: Unknown (0) Data Valid But Above Normal Operational Range - Most Severe Level (0) 0 times";
+        assertEquals(expected, instance.toString());
+    }
+}

--- a/src/org/etools/j1939_84/bus/j1939/packets/DTCLampStatus.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/DTCLampStatus.java
@@ -6,6 +6,7 @@ package org.etools.j1939_84.bus.j1939.packets;
 import static org.etools.j1939_84.J1939_84.NL;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.etools.j1939_84.bus.Packet;
 
@@ -26,10 +27,22 @@ public class DTCLampStatus {
      * Constructor
      *
      * @param int[]
-     * the {@link Packet} to parse
+     *            the {@link Packet} to parse
      */
     public DTCLampStatus(int[] data) {
         this.data = Arrays.copyOf(data, data.length);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof DTCLampStatus)) {
+            return false;
+        }
+        DTCLampStatus that = (DTCLampStatus) obj;
+        return Arrays.equals(getData(), that.getData());
     }
 
     /**
@@ -48,27 +61,27 @@ public class DTCLampStatus {
      * Helper method to get one byte at the given index
      *
      * @param index
-     * the index of the byte to get
+     *            the index of the byte to get
      * @return one byte
      */
-    protected byte getByte(int index) {
+    private byte getByte(int index) {
         return (byte) (getData()[index] & 0xFF);
     }
 
     /**
      * @return the data
      */
-    public int[] getData() {
+    private int[] getData() {
         return data;
     }
 
     /**
-     * Returns the a link to a {@link DiagnosticTroubleCode}. If the only
-     * "DTC" has an SPN of 0 or 524287, the list will be empty, but never null
+     * Returns the a link to a {@link DiagnosticTroubleCode}. If the only "DTC"
+     * has an SPN of 0 or 524287, the list will be empty, but never null
      *
      * @return DTC
      */
-    public DiagnosticTroubleCode getDtc() {
+    public DiagnosticTroubleCode getDtcs() {
         if (dtc == null) {
             dtc = parseDTC();
         }
@@ -79,14 +92,14 @@ public class DTCLampStatus {
      * Helper method to get a {@link LampStatus}
      *
      * @param mask
-     * the bit mask
+     *            the bit mask
      * @param shift
-     * the number of bits to shift to the right
+     *            the number of bits to shift to the right
      * @return the {@link LampStatus} that corresponds to the value
      */
     private LampStatus getLampStatus(int mask, int shift) {
-        int onOff = getShaveAndAHaircut(0, mask, shift);
-        int flash = getShaveAndAHaircut(1, mask, shift);
+        int onOff = getShaveAndAHaircut(4, mask, shift);
+        int flash = getShaveAndAHaircut(5, mask, shift);
         return LampStatus.getStatus(onOff, flash);
     }
 
@@ -130,18 +143,39 @@ public class DTCLampStatus {
      * Helper method to get two bits at the given byte index
      *
      * @param index
-     * the index of the byte that contains the bits
+     *            the index of the byte that contains the bits
      * @param mask
-     * the bit mask for the bits
+     *            the bit mask for the bits
      * @param shift
-     * the number bits to shift right so the two bits are fully right
-     * shifted
+     *            the number bits to shift right so the two bits are fully right
+     *            shifted
      * @return two bit value
      */
     private int getShaveAndAHaircut(int index, int mask, int shift) {
         return (getByte(index) & mask) >> shift;
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(getAmberWarningLampStatus(),
+                getMalfunctionIndicatorLampStatus(),
+                getProtectLampStatus(),
+                getRedStopLampStatus(),
+                getDtcs());
+    }
+
+    /**
+     * Helper method to get two bits at the given byte index
+     *
+     * @param index
+     *            the index of the byte that contains the bits
+     * @param mask
+     *            the bit mask for the bits
+     * @param shift
+     *            the number bits to shift right so the two bits are fully right
+     *            shifted
+     * @return two bit value
+     */
     private DiagnosticTroubleCode parseDTC() {
         return new DiagnosticTroubleCode(Arrays.copyOfRange(data, 0, 4));
     }
@@ -151,9 +185,7 @@ public class DTCLampStatus {
         String result = "MIL: " + getMalfunctionIndicatorLampStatus() + ", RSL: "
                 + getRedStopLampStatus() + ", AWL: " + getAmberWarningLampStatus() + ", PL: " + getProtectLampStatus()
                 + NL;
-        result += getDtc().toString();
-
+        result += getDtcs().toString();
         return result;
     }
-
 }


### PR DESCRIPTION
Fix #197 update the DTCLampStatus to correctly parse lamp statuses and write additional tests.