### PR TITLE
Correct tests to use correct lamp states in the packets values

### DIFF
--- a/src-test/org/etools/j1939_84/bus/j1939/packets/DM28PermanentEmissionDTCPacketTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/packets/DM28PermanentEmissionDTCPacketTest.java
@@ -30,7 +30,7 @@ public class DM28PermanentEmissionDTCPacketTest {
 
     @Test
     public void testToString() {
-        int[] data = { 0x43, 0xFF, 0x9D, 0x00, 0x07, 0x01, 0xFF, 0xFF };
+        int[] data = { 0x42, 0xFD, 0x9D, 0x00, 0x07, 0x01, 0xFF, 0xFF };
         Packet packet = Packet.create(0, 0, data);
         DM28PermanentEmissionDTCPacket dm28Packet = new DM28PermanentEmissionDTCPacket(packet);
         StringBuilder expected = new StringBuilder(

--- a/src-test/org/etools/j1939_84/bus/j1939/packets/DM31ScaledTestResultTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/packets/DM31ScaledTestResultTest.java
@@ -36,9 +36,9 @@ public class DM31ScaledTestResultTest {
                 0x61, // SPN least significant bit
                 0x02, // SPN most significant bit
                 0x13, // Failure mode indicator
-                0x81,
-                0x58,
-                0x34
+                0x81, // SPN Conversion Occurrence Count
+                0x62, // Lamp Status/Support
+                0x1D, // Lamp Status/State
         };
         Packet packet = Packet.create(DM31ScaledTestResults.PGN,
                 0,
@@ -53,7 +53,7 @@ public class DM31ScaledTestResultTest {
         assertEquals(expected, instance.toString());
 
         DTCLampStatus dtcLampStatus0 = instance.getDtcLampStatuses().get(0);
-        DiagnosticTroubleCode actualDTC = dtcLampStatus0.getDtc();
+        DiagnosticTroubleCode actualDTC = dtcLampStatus0.getDtcs();
         assertEquals(0x0261, actualDTC.getSuspectParameterNumber());
         assertEquals(0x01, actualDTC.getConversionMethod());
         assertEquals(0x13, actualDTC.getFailureModeIndicator());
@@ -76,23 +76,24 @@ public class DM31ScaledTestResultTest {
                 0x61, // SPN least significant bit
                 0x02, // SPN most significant bit
                 0x13, // Failure mode indicator
-                0x81,
-                0x58,
-                0x34,
+                0x81, // SPN Conversion Occurrence Count
+                0x62, // Lamp Status/Support
+                0x1D, // Lamp Status/State
 
                 0x21, // SPN least significant bit
                 0x06, // SPN most significant bit
                 0x1F, // Failure mode indicator
-                0x23,
-                0x4A,
-                0x34,
+                0x23, // SPN Conversion Occurrence Count
+                0x22, // Lamp Status/Support
+                0xDD, // Lamp Status/State
 
                 0xEE, // SPN least significant bit
                 0x10, // SPN most significant bit
                 0x04, // Failure mode indicator
-                0x00,
-                0x37,
-                0x2A);
+                0x00, // SPN Conversion Occurrence Count
+                0xAA, // Lamp Status/Support
+                0x55);// Lamp Status/State
+
         DM31ScaledTestResults instance = new DM31ScaledTestResults(packet);
         assertEquals("DM31", instance.getName());
         List<DTCLampStatus> lampStatuses = instance.getDtcLampStatuses();
@@ -110,7 +111,7 @@ public class DM31ScaledTestResultTest {
         assertEquals(expected, instance.toString());
 
         DTCLampStatus lampStatus0 = lampStatuses.get(0);
-        DiagnosticTroubleCode dtc0 = lampStatus0.getDtc();
+        DiagnosticTroubleCode dtc0 = lampStatus0.getDtcs();
         assertEquals(0x01, dtc0.getConversionMethod());
         assertEquals(0x13, dtc0.getFailureModeIndicator());
         assertEquals(0x01, dtc0.getOccurrenceCount());
@@ -121,7 +122,7 @@ public class DM31ScaledTestResultTest {
         assertEquals(LampStatus.OFF, instance.getDtcLampStatuses().get(0).getAmberWarningLampStatus());
 
         DTCLampStatus lampStatus1 = lampStatuses.get(1);
-        DiagnosticTroubleCode dtc1 = lampStatus1.getDtc();
+        DiagnosticTroubleCode dtc1 = lampStatus1.getDtcs();
         assertEquals(0x0, dtc1.getConversionMethod());
         assertEquals(0x1F, dtc1.getFailureModeIndicator());
         assertEquals(0x23, dtc1.getOccurrenceCount());
@@ -132,7 +133,7 @@ public class DM31ScaledTestResultTest {
         assertEquals(LampStatus.OFF, lampStatus1.getAmberWarningLampStatus());
 
         DTCLampStatus lampStatus2 = lampStatuses.get(2);
-        DiagnosticTroubleCode dtc2 = lampStatus2.getDtc();
+        DiagnosticTroubleCode dtc2 = lampStatus2.getDtcs();
         assertEquals(0x00, dtc2.getConversionMethod());
         assertEquals(0x04, dtc2.getFailureModeIndicator());
         assertEquals(0x00, dtc2.getOccurrenceCount());

--- a/src-test/org/etools/j1939_84/bus/j1939/packets/DM6PendingEmissionDTCPacketTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/packets/DM6PendingEmissionDTCPacketTest.java
@@ -69,7 +69,7 @@ public class DM6PendingEmissionDTCPacketTest {
     @Test
     public void testToString() {
         // Test two on and rest off
-        Packet packet = Packet.create(0, 0, 0x11, 0x01, 0x01, 0x01, 0x01, 0x01, 0x31, 0x11);
+        Packet packet = Packet.create(0, 0, 0x11, 0xCD, 0x01, 0x01, 0x01, 0x01, 0x31, 0x11);
         DM6PendingEmissionDTCPacket instance = new DM6PendingEmissionDTCPacket(packet);
         assertEquals(LampStatus.OFF, instance.getAmberWarningLampStatus());
         assertEquals(LampStatus.FAST_FLASH, instance.getProtectLampStatus());

--- a/src-test/org/etools/j1939_84/bus/j1939/packets/DiagnosticTroubleCodePacketTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/packets/DiagnosticTroubleCodePacketTest.java
@@ -31,7 +31,7 @@ public class DiagnosticTroubleCodePacketTest {
 
     @Test
     public void testGetAmberWarningLampStatusOff() {
-        int[] data = new int[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+        int[] data = new int[] { 0x00, 0x0C, 0x00, 0x00, 0x00, 0x00 };
         Packet packet = Packet.create(0x00, 0x00, data);
         DiagnosticTroubleCodePacket instance = new DiagnosticTroubleCodePacket(packet);
 
@@ -132,7 +132,7 @@ public class DiagnosticTroubleCodePacketTest {
 
     @Test
     public void testGetMalfunctionIndicatorLampStatusOff() {
-        int[] data = new int[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+        int[] data = new int[] { 0x00, 0x0C0, 0x00, 0x00, 0x00, 0x00 };
         Packet packet = Packet.create(0x00, 0x00, data);
         DiagnosticTroubleCodePacket instance = new DiagnosticTroubleCodePacket(packet);
 
@@ -172,7 +172,7 @@ public class DiagnosticTroubleCodePacketTest {
 
     @Test
     public void testGetProtectLampStatusOff() {
-        int[] data = new int[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+        int[] data = new int[] { 0x00, 0xFF, 0x00, 0x00, 0x00, 0x00 };
         Packet packet = Packet.create(0x00, 0x00, data);
         DiagnosticTroubleCodePacket instance = new DiagnosticTroubleCodePacket(packet);
 
@@ -212,7 +212,7 @@ public class DiagnosticTroubleCodePacketTest {
 
     @Test
     public void testGetRedStopLampStatusOff() {
-        int[] data = new int[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+        int[] data = new int[] { 0x00, 0x30, 0x00, 0x00, 0x00, 0x00 };
         Packet packet = Packet.create(0x00, 0x00, data);
         DiagnosticTroubleCodePacket instance = new DiagnosticTroubleCodePacket(packet);
 
@@ -254,7 +254,7 @@ public class DiagnosticTroubleCodePacketTest {
 
     @Test
     public void testToStringNoDtcs() {
-        int[] data = new int[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+        int[] data = new int[] { 0x00, 0xFF, 0x00, 0x00, 0x00, 0x00 };
         Packet packet = Packet.create(0x123456, 0x00, data);
         DiagnosticTroubleCodePacket instance = new DiagnosticTroubleCodePacket(packet);
         String expected = "DM from Engine #1 (0): MIL: off, RSL: off, AWL: off, PL: off, No DTCs";


### PR DESCRIPTION
Fix #195 add two additional  states of "alternate off" and "not supported" to implement Section A.8 from the requirements.