### PR TITLE
Fix Part01Step13 logic and verbiage

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part1/Step13ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Step13ControllerTest.java
@@ -81,9 +81,6 @@ public class Step13ControllerTest extends AbstractControllerTest {
     @Mock
     private OBDModuleInformation obdModuleInformation;
 
-    //    @Mock
-    //    private ReportFileModule reportFileModule;
-
     @Mock
     private SectionA6Validator sectionA6Validator;
 
@@ -141,29 +138,34 @@ public class Step13ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testRun() {
-        final int pgn = DM5DiagnosticReadinessPacket.PGN;
 
         DM5DiagnosticReadinessPacket packet0 = new DM5DiagnosticReadinessPacket(
-                Packet.create(pgn, 0x00, 0x00, 0x00, 0x14, 0x37, 0xE0, 0x1E, 0xE0, 0x1E));
+                Packet.create(PGN, 0x00, 0x00, 0x00, 0x14, 0x37, 0xE0, 0x1E, 0xE0, 0x1E));
         DM5DiagnosticReadinessPacket packet17 = new DM5DiagnosticReadinessPacket(
-                Packet.create(pgn, 0x17, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00));
-        DM5DiagnosticReadinessPacket packet23 = new DM5DiagnosticReadinessPacket(
-                Packet.create(pgn, 0x21, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00));
+                Packet.create(PGN, 0x17, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00));
+        DM5DiagnosticReadinessPacket packet21 = new DM5DiagnosticReadinessPacket(
+                Packet.create(PGN, 0x21, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00));
         RequestResult<DM5DiagnosticReadinessPacket> globalRequestResponse = new RequestResult<>(
-                false, List.of(packet0, packet17, packet23), Collections.emptyList());
+                false, List.of(packet0, packet17, packet21), Collections.emptyList());
         when(diagnosticReadinessModule.requestDM5(any(), eq(true))).thenReturn(globalRequestResponse);
 
         BusResult<DM5DiagnosticReadinessPacket> busResult0x00 = new BusResult<>(false, packet0);
         when(diagnosticReadinessModule.requestDM5(any(), eq(true), eq(0x00))).thenReturn(busResult0x00);
         BusResult<DM5DiagnosticReadinessPacket> busResult0x17 = new BusResult<>(false, packet17);
         when(diagnosticReadinessModule.requestDM5(any(), eq(true), eq(0x17))).thenReturn(busResult0x17);
-        BusResult<DM5DiagnosticReadinessPacket> busResult0x23 = new BusResult<>(false, packet23);
-        when(diagnosticReadinessModule.requestDM5(any(), eq(true), eq(0x23))).thenReturn(busResult0x23);
+        BusResult<DM5DiagnosticReadinessPacket> busResult0x21 = new BusResult<>(false, packet21);
+        when(diagnosticReadinessModule.requestDM5(any(), eq(true), eq(0x21))).thenReturn(busResult0x21);
 
         when(sectionA6Validator.verify(any(), eq(PART_NUMBER), eq(STEP_NUMBER), eq(globalRequestResponse))).thenReturn(
                 true);
 
-        when(dataRepository.getObdModuleAddresses()).thenReturn(List.of(0x00, 0x17, 0x23));
+        when(dataRepository.getObdModuleAddresses()).thenReturn(new ArrayList<>() {
+            {
+                add(0x00);
+                add(0x17);
+                add(0x21);
+            }
+        });
 
         runTest();
 
@@ -174,34 +176,29 @@ public class Step13ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getMilestones());
         String expectedVehicleComposite = NL + "Vehicle Composite of DM5:" + NL +
-                "    A/C system refrigerant         not supported,       completed" + NL +
-                "    Boost pressure control sys         supported,   not completed" + NL +
-                "    Catalyst                       not supported,       completed" + NL +
-                "    Cold start aid system          not supported,       completed" + NL +
-                "    Comprehensive component            supported,       completed" + NL +
-                "    Diesel Particulate Filter          supported,   not completed" + NL +
-                "    EGR/VVT system                     supported,   not completed" + NL +
-                "    Evaporative system             not supported,       completed" + NL +
-                "    Exhaust Gas Sensor                 supported,   not completed" + NL +
-                "    Exhaust Gas Sensor heater          supported,   not completed" + NL +
-                "    Fuel System                        supported,   not completed" + NL +
-                "    Heated catalyst                not supported,       completed" + NL +
-                "    Misfire                            supported,   not completed" + NL +
-                "    NMHC converting catalyst           supported,   not completed" + NL +
-                "    NOx catalyst/adsorber              supported,   not completed" + NL +
-                "    Secondary air system           not supported,       completed" + NL;
+                "    A/C system refrigerant     not supported,     complete" + NL +
+                "    Boost pressure control sys     supported, not complete" + NL +
+                "    Catalyst                   not supported,     complete" + NL +
+                "    Cold start aid system      not supported,     complete" + NL +
+                "    Comprehensive component        supported,     complete" + NL +
+                "    Diesel Particulate Filter      supported, not complete" + NL +
+                "    EGR/VVT system                 supported, not complete" + NL +
+                "    Evaporative system         not supported,     complete" + NL +
+                "    Exhaust Gas Sensor             supported, not complete" + NL +
+                "    Exhaust Gas Sensor heater      supported, not complete" + NL +
+                "    Fuel System                    supported, not complete" + NL +
+                "    Heated catalyst            not supported,     complete" + NL +
+                "    Misfire                        supported, not complete" + NL +
+                "    NMHC converting catalyst       supported, not complete" + NL +
+                "    NOx catalyst/adsorber          supported, not complete" + NL +
+                "    Secondary air system       not supported,     complete" + NL;
         assertEquals(expectedVehicleComposite + NL, listener.getResults());
     }
 
     @Test
     public void testStep13DM5PacketsEmpty() {
-        DM5DiagnosticReadinessPacket packet0 = new DM5DiagnosticReadinessPacket(
-                Packet.create(PGN, 0x00, 0x00, 0x00, 0x14, 0x37, 0xE0, 0x1E, 0xE0, 0x1E));
-        final int ackPgn = DM5DiagnosticReadinessPacket.PGN;
         AcknowledgmentPacket packet44 = new AcknowledgmentPacket(
-                Packet.create(ackPgn, 0x44, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08));
-        DM5DiagnosticReadinessPacket packet21 = new DM5DiagnosticReadinessPacket(
-                Packet.create(PGN, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
+                Packet.create(PGN, 0x44, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08));
         RequestResult<DM5DiagnosticReadinessPacket> globalRequestResponse = new RequestResult<>(false,
                                                                                                 Collections.emptyList(),
                                                                                                 Collections.singletonList(
@@ -209,62 +206,13 @@ public class Step13ControllerTest extends AbstractControllerTest {
         when(diagnosticReadinessModule.requestDM5(any(), eq(true))).thenReturn(globalRequestResponse);
 
         BusResult<DM5DiagnosticReadinessPacket> busResult0x00 = new BusResult<>(false,
-                                                                                packet0);
-        when(diagnosticReadinessModule.requestDM5(any(), eq(true), eq(0x00))).thenReturn(busResult0x00);
-        BusResult<DM5DiagnosticReadinessPacket> busResult0x17 = new BusResult<>(false,
-                                                                                packet44);
-        when(diagnosticReadinessModule.requestDM5(any(), eq(true), eq(0x17))).thenReturn(busResult0x17);
-        BusResult<DM5DiagnosticReadinessPacket> busResult0x21 = new BusResult<>(false,
-                                                                                packet21);
-        when(diagnosticReadinessModule.requestDM5(any(), eq(true), eq(0x21))).thenReturn(busResult0x21);
-
-        when(sectionA6Validator.verify(any(), eq(PART_NUMBER), eq(STEP_NUMBER), eq(globalRequestResponse))).thenReturn(
-                false);
-
-        when(dataRepository.getObdModuleAddresses()).thenReturn(List.of(0x00, 0x17, 0x21));
-
-        runTest();
-
-        verify(dataRepository).getObdModuleAddresses();
-
-        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                        "6.1.13.1.a - Global DM5 request did not receive any response packets");
-        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                        "6.1.13.2.c - No OBD ECU provided DM5 with readiness bits showing monitor support");
-
-        verify(sectionA6Validator).verify(any(), eq(PART_NUMBER), eq(STEP_NUMBER), eq(globalRequestResponse));
-
-        assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
-
-        String expectedResults = "FAIL: 6.1.13.1.a - Global DM5 request did not receive any response packets" + NL;
-        expectedResults += "FAIL: 6.1.13.2.c - No OBD ECU provided DM5 with readiness bits showing monitor support" + NL;
-        assertEquals(expectedResults, listener.getResults());
-    }
-
-    @Test
-    public void testStep13DM5PacketsFail() {
-        final int pgn = DM5DiagnosticReadinessPacket.PGN;
-        DM5DiagnosticReadinessPacket packet0 = new DM5DiagnosticReadinessPacket(
-                Packet.create(pgn, 0x00, 0x03, 0x10, 0x14, 0x37, 0xE0, 0x1E, 0xE0, 0x1E));
-        DM5DiagnosticReadinessPacket packet17 = new DM5DiagnosticReadinessPacket(
-                Packet.create(pgn, 0x21, 0x00, 0x00, 0x14, 0x37, 0xE0, 0x1E, 0xE0, 0x1E));
-        final int ackPgn = AcknowledgmentPacket.PGN;
-        AcknowledgmentPacket packet21 = new AcknowledgmentPacket(
-                Packet.create(ackPgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
-        RequestResult<DM5DiagnosticReadinessPacket> globalRequestResponse = new RequestResult<>(
-                false, Arrays.asList(packet0, packet17),
-                Collections.singletonList(packet21));
-        when(diagnosticReadinessModule.requestDM5(any(), eq(true))).thenReturn(globalRequestResponse);
-
-        BusResult<DM5DiagnosticReadinessPacket> busResult0x00 = new BusResult<>(false,
                                                                                 Optional.empty());
         when(diagnosticReadinessModule.requestDM5(any(), eq(true), eq(0x00))).thenReturn(busResult0x00);
         BusResult<DM5DiagnosticReadinessPacket> busResult0x17 = new BusResult<>(false,
                                                                                 Optional.empty());
         when(diagnosticReadinessModule.requestDM5(any(), eq(true), eq(0x17))).thenReturn(busResult0x17);
         BusResult<DM5DiagnosticReadinessPacket> busResult0x21 = new BusResult<>(false,
-                                                                                packet21);
+                                                                                Optional.empty());
         when(diagnosticReadinessModule.requestDM5(any(), eq(true), eq(0x21))).thenReturn(busResult0x21);
 
         when(sectionA6Validator.verify(any(), eq(PART_NUMBER), eq(STEP_NUMBER), eq(globalRequestResponse))).thenReturn(
@@ -283,24 +231,71 @@ public class Step13ControllerTest extends AbstractControllerTest {
         verify(dataRepository).getObdModuleAddresses();
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                        "6.1.13.2.b - An OBD ECU reported active/previously active fault DTCs count not = 0/0" + NL
-                                                + "  Reported active fault count = 3" + NL + "  Reported previously active fault count = 16");
-        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, WARN,
-                                        "6.1.13.3 - OBD module Engine #1 (0) did not return a response to a destination specific request");
-        verify(mockListener).addOutcome(PART_NUMBER,
-                                        STEP_NUMBER,
-                                        WARN,
-                                        "6.1.13.3 - OBD module Instrument Cluster #1 (23) did not return a response to a destination specific request");
+                                        "6.1.13.1.a - Global DM5 request did not receive any response packets");
+        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
+                                        "6.1.13.2.c - No OBD ECU provided DM5 with readiness bits showing monitor support");
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, WARN,
                                         "6.1.13.3.a - Destination Specific DM5 requests to OBD modules did not return any responses");
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                        "6.1.13.4.a - A difference compared to data received during global request");
-
-        verify(mockListener).addOutcome(PART_NUMBER,
-                                        STEP_NUMBER,
-                                        FAIL,
                                         "6.1.13.4.b - NACK not received from OBD ECUs that did not respond to global query");
 
+        verify(sectionA6Validator).verify(any(), eq(PART_NUMBER), eq(STEP_NUMBER), eq(globalRequestResponse));
+
+        assertEquals("", listener.getMessages());
+        assertEquals("", listener.getMilestones());
+
+        String expectedResults = "FAIL: 6.1.13.1.a - Global DM5 request did not receive any response packets" + NL;
+        expectedResults += "FAIL: 6.1.13.2.c - No OBD ECU provided DM5 with readiness bits showing monitor support" + NL;
+        expectedResults += "WARN: 6.1.13.3.a - Destination Specific DM5 requests to OBD modules did not return any responses" + NL;
+        assertEquals(expectedResults, listener.getResults());
+    }
+
+    @Test
+    public void testStep13DM5PacketsFail() {
+        final int pgn = DM5DiagnosticReadinessPacket.PGN;
+        DM5DiagnosticReadinessPacket packet0 = new DM5DiagnosticReadinessPacket(
+                Packet.create(pgn, 0x00, 0x03, 0x10, 0x14, 0x37, 0xE0, 0x1E, 0xE0, 0x1E));
+        DM5DiagnosticReadinessPacket packet21 = new DM5DiagnosticReadinessPacket(
+                Packet.create(pgn, 0x21, 0x00, 0x00, 0x14, 0x37, 0xE0, 0x1E, 0xE0, 0x1E));
+        DM5DiagnosticReadinessPacket packet21V2 = new DM5DiagnosticReadinessPacket(
+                Packet.create(pgn, 0x21, 0x00, 0x00, 0x00, 0x00, 0xE0, 0x1E, 0xE0, 0x1E));
+
+        final int ackPgn = AcknowledgmentPacket.PGN;
+        AcknowledgmentPacket packet23 = new AcknowledgmentPacket(
+                Packet.create(ackPgn, 0x23, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
+        RequestResult<DM5DiagnosticReadinessPacket> globalRequestResponse = new RequestResult<>(
+                false, Arrays.asList(packet0, packet21),
+                Collections.singletonList(packet23));
+        when(diagnosticReadinessModule.requestDM5(any(), eq(true))).thenReturn(globalRequestResponse);
+
+        BusResult<DM5DiagnosticReadinessPacket> busResult0x00 = new BusResult<>(false,
+                                                                                Optional.empty());
+        when(diagnosticReadinessModule.requestDM5(any(), eq(true), eq(0x00))).thenReturn(busResult0x00);
+        BusResult<DM5DiagnosticReadinessPacket> busResult0x17 = new BusResult<>(false,
+                                                                                Optional.empty());
+        when(diagnosticReadinessModule.requestDM5(any(), eq(true), eq(0x17))).thenReturn(busResult0x17);
+        BusResult<DM5DiagnosticReadinessPacket> busResult0x21 = new BusResult<>(false,
+                                                                                packet21V2);
+        when(diagnosticReadinessModule.requestDM5(any(), eq(true), eq(0x21))).thenReturn(busResult0x21);
+        BusResult<DM5DiagnosticReadinessPacket> busResult0x23 = new BusResult<>(false,
+                                                                                packet23);
+        when(diagnosticReadinessModule.requestDM5(any(), eq(true), eq(0x23))).thenReturn(busResult0x23);
+
+        when(sectionA6Validator.verify(any(), eq(PART_NUMBER), eq(STEP_NUMBER), eq(globalRequestResponse))).thenReturn(
+                false);
+
+        when(dataRepository.getObdModuleAddresses()).thenReturn(new ArrayList<>() {
+            {
+                add(0x00);
+                add(0x17);
+                add(0x21);
+                add(0x23);
+            }
+        });
+
+        runTest();
+
+        verify(dataRepository).getObdModuleAddresses();
         String expected2dWarning = "6.1.13.2.d - An individual required monitor is supported by more than one OBD ECU" + NL +
                 "Boost pressure control sys has reporting from more than one OBD ECU" + NL +
                 "Diesel Particulate Filter  has reporting from more than one OBD ECU" + NL +
@@ -311,40 +306,46 @@ public class Step13ControllerTest extends AbstractControllerTest {
                 "Misfire                    has reporting from more than one OBD ECU" + NL +
                 "NMHC converting catalyst   has reporting from more than one OBD ECU" + NL +
                 "NOx catalyst/adsorber      has reporting from more than one OBD ECU";
-        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, WARN, expected2dWarning);
+
+        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
+                                        "6.1.13.2.b - An OBD ECU reported active/previously active fault DTCs count not = 0/0" + NL
+                                                + "  Reported active fault count = 3" + NL + "  Reported previously active fault count = 16");
+        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, WARN,
+                                        expected2dWarning);
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.1.13.4.a - Difference compared to data received during global request");
+        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
+                                        "6.1.13.4.b - NACK not received from OBD ECUs that did not respond to global query");
 
         verify(sectionA6Validator).verify(any(), eq(PART_NUMBER), eq(STEP_NUMBER), eq(globalRequestResponse));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getMilestones());
         String expectedVehicleComposite = NL + "Vehicle Composite of DM5:" + NL +
-                "    A/C system refrigerant         not supported,       completed" + NL +
-                "    Boost pressure control sys         supported,   not completed" + NL +
-                "    Catalyst                       not supported,       completed" + NL +
-                "    Cold start aid system          not supported,       completed" + NL +
-                "    Comprehensive component            supported,       completed" + NL +
-                "    Diesel Particulate Filter          supported,   not completed" + NL +
-                "    EGR/VVT system                     supported,   not completed" + NL +
-                "    Evaporative system             not supported,       completed" + NL +
-                "    Exhaust Gas Sensor                 supported,   not completed" + NL +
-                "    Exhaust Gas Sensor heater          supported,   not completed" + NL +
-                "    Fuel System                        supported,   not completed" + NL +
-                "    Heated catalyst                not supported,       completed" + NL +
-                "    Misfire                            supported,   not completed" + NL +
-                "    NMHC converting catalyst           supported,   not completed" + NL +
-                "    NOx catalyst/adsorber              supported,   not completed" + NL +
-                "    Secondary air system           not supported,       completed" + NL;
+                "    A/C system refrigerant     not supported,     complete" + NL +
+                "    Boost pressure control sys     supported, not complete" + NL +
+                "    Catalyst                   not supported,     complete" + NL +
+                "    Cold start aid system      not supported,     complete" + NL +
+                "    Comprehensive component        supported,     complete" + NL +
+                "    Diesel Particulate Filter      supported, not complete" + NL +
+                "    EGR/VVT system                 supported, not complete" + NL +
+                "    Evaporative system         not supported,     complete" + NL +
+                "    Exhaust Gas Sensor             supported, not complete" + NL +
+                "    Exhaust Gas Sensor heater      supported, not complete" + NL +
+                "    Fuel System                    supported, not complete" + NL +
+                "    Heated catalyst            not supported,     complete" + NL +
+                "    Misfire                        supported, not complete" + NL +
+                "    NMHC converting catalyst       supported, not complete" + NL +
+                "    NOx catalyst/adsorber          supported, not complete" + NL +
+                "    Secondary air system       not supported,     complete" + NL;
+
         String expectedResults = expectedVehicleComposite + NL;
         expectedResults += "FAIL: 6.1.13.2.b - An OBD ECU reported active/previously active fault DTCs count not = 0/0" + NL;
         expectedResults += "  Reported active fault count = 3" + NL;
         expectedResults += "  Reported previously active fault count = 16" + NL;
-
         expectedResults += "WARN: " + expected2dWarning + NL;
-        expectedResults += "WARN: 6.1.13.3 - OBD module Engine #1 (0) did not return a response to a destination specific request" + NL;
-        expectedResults += "WARN: 6.1.13.3 - OBD module Instrument Cluster #1 (23) did not return a response to a destination specific request" + NL;
-        expectedResults += "WARN: 6.1.13.3.a - Destination Specific DM5 requests to OBD modules did not return any responses" + NL;
-        expectedResults += "FAIL: 6.1.13.4.a - A difference compared to data received during global request" + NL;
-        expectedResults += "FAIL: 6.1.13.4.b - NACK not received from OBD ECUs that did not respond to global query" + NL;
         assertEquals(expectedResults, listener.getResults());
     }
 }


### PR DESCRIPTION
Fix #449 Update the verbiage per client feedback on the reporting as well as fix incorrect logic when computing the differences between packets.