### PR TITLE
Fix #426 Various Part1 Steps Report Global and DS Response differences inaccurately

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part1/Step14ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Step14ControllerTest.java
@@ -404,8 +404,6 @@ public class Step14ControllerTest extends AbstractControllerTest {
                                         "6.1.14.2.e - Response indicates time since engine start is not zero" + NL +
                                                 "DM26 from Engine #2 (1): Warm-ups: 51, Time Since Engine Start: 8,721 seconds"
                                                 + NL);
-        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, WARN,
-                                        "6.1.14.4.a - Destination Specific DM5 requests to OBD modules did not return any responses");
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
                                         "6.1.14.2.e - Response indicates time since engine start is not zero" + NL +
                                                 "DM26 from Transmission #1 (3): Warm-ups: 10, Time Since Engine Start: 8,721 seconds" + NL);
@@ -419,12 +417,6 @@ public class Step14ControllerTest extends AbstractControllerTest {
                                                 + NL + "Diesel Particulate Filter  has reporting from more than one OBD ECU"
                                                 + NL + "Evaporative system         has reporting from more than one OBD ECU"
                                                 + NL + "Exhaust Gas Sensor heater  has reporting from more than one OBD ECU");
-        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, WARN,
-                                        "6.1.14.4.a - Destination Specific DM5 requests to OBD modules did not return any responses");
-        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                        "6.1.14.5.a - Difference compared to data received during global request");
-        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                        "6.1.14.5.b - NACK not received from OBD ECUs that did not respond to global query");
 
         String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
         expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
@@ -487,12 +479,6 @@ public class Step14ControllerTest extends AbstractControllerTest {
         expectedResults += "Evaporative system         has reporting from more than one OBD ECU"
                 + NL;
         expectedResults += "Exhaust Gas Sensor heater  has reporting from more than one OBD ECU"
-                + NL;
-        expectedResults += "WARN: 6.1.14.4.a - Destination Specific DM5 requests to OBD modules did not return any responses"
-                + NL;
-        expectedResults += "FAIL: 6.1.14.5.a - Difference compared to data received during global request"
-                + NL;
-        expectedResults += "FAIL: 6.1.14.5.b - NACK not received from OBD ECUs that did not respond to global query"
                 + NL;
         assertEquals(expectedResults, listener.getResults());
     }

--- a/src-test/org/etools/j1939_84/controllers/part1/Step19ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Step19ControllerTest.java
@@ -5,18 +5,13 @@ package org.etools.j1939_84.controllers.part1;
 
 import static org.etools.j1939_84.J1939_84.NL;
 import static org.etools.j1939_84.model.Outcome.FAIL;
-import static org.etools.j1939_84.model.Outcome.WARN;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executor;
@@ -121,11 +116,11 @@ public class Step19ControllerTest extends AbstractControllerTest {
      */
     @Test
     public void testEmptyPacketFailure() {
-        List<Integer> obdModuleAddresses = Collections.singletonList(0x01);
+        List<Integer> obdModuleAddresses = List.of(0x01);
         when(dataRepository.getObdModuleAddresses()).thenReturn(obdModuleAddresses);
 
         when(dtcModule.requestDM23(any(), eq(true)))
-                .thenReturn(new RequestResult<>(false, Collections.emptyList(), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, List.of(), List.of()));
         when(dtcModule.requestDM23(any(), eq(true), eq(0x01)))
                 .thenReturn(new BusResult<>(false, Optional.empty()));
 
@@ -137,17 +132,12 @@ public class Step19ControllerTest extends AbstractControllerTest {
         verify(dtcModule).requestDM23(any(), eq(true), eq(0x01));
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                        "6.1.19.2.c - Fail if no OBD ECU provides DM23");
-        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, WARN,
-                                        "6.1.19.3 OBD module Engine #2 (1) did not return a response to a destination specific request");
-        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, WARN,
-                                        "6.1.19.3.a Destination Specific DM23 requests to OBD modules did not return any responses");
+                                        "6.1.19.2.c - No OBD ECU provided DM23");
+        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
+                                        "6.1.19.4.b - OBD module Engine #2 (1) did not provide a response to Global query and did not provide a NACK for the DS query");
 
-        String expectedResults = "FAIL: 6.1.19.2.c - Fail if no OBD ECU provides DM23" + NL;
-        expectedResults += "WARN: 6.1.19.3 OBD module Engine #2 (1) did not return a response to a destination specific request"
-                + NL;
-        expectedResults += "WARN: 6.1.19.3.a Destination Specific DM23 requests to OBD modules did not return any responses"
-                + NL;
+        String expectedResults = "FAIL: 6.1.19.2.c - No OBD ECU provided DM23" + NL;
+        expectedResults += "FAIL: 6.1.19.4.b - OBD module Engine #2 (1) did not provide a response to Global query and did not provide a NACK for the DS query" + NL;
         assertEquals(expectedResults, listener.getResults());
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getMilestones());
@@ -164,24 +154,14 @@ public class Step19ControllerTest extends AbstractControllerTest {
                 Packet.create(PGN, 0x01, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88));
         DM23PreviouslyMILOnEmissionDTCPacket packet3 = new DM23PreviouslyMILOnEmissionDTCPacket(
                 Packet.create(PGN, 0x03, 0x00, 0x00, 0x04, 0x00, 0xFF, 0xFF, 0xFF, 0xFF));
-        List<Integer> obdModuleAddresses = new ArrayList<>() {
-            {
-                add(0x01);
-                add(0x03);
-            }
-        };
+        List<Integer> obdModuleAddresses = List.of(1,3);
         when(dataRepository.getObdModuleAddresses()).thenReturn(obdModuleAddresses);
 
         DM23PreviouslyMILOnEmissionDTCPacket obdPacket3 = new DM23PreviouslyMILOnEmissionDTCPacket(
                 Packet.create(PGN, 0x03, 0x11, 0x22, 0x13, 0x44, 0x55, 0x66, 0x77, 0x88));
 
         when(dtcModule.requestDM23(any(), eq(true)))
-                .thenReturn(new RequestResult<>(false, new ArrayList<>() {
-                    {
-                        add(packet1);
-                        add(packet3);
-                    }
-                }, Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, List.of(packet1, packet3), List.of()));
 
         when(dtcModule.requestDM23(any(), eq(true), eq(0x01)))
                 .thenReturn(new BusResult<>(false, packet1));
@@ -196,19 +176,16 @@ public class Step19ControllerTest extends AbstractControllerTest {
         verify(dtcModule).requestDM23(any(), eq(true), eq(0x01));
         verify(dtcModule).requestDM23(any(), eq(true), eq(0x03));
 
-        verify(mockListener, times(2)).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                                  "6.1.19.2.a - Fail if any ECU reports active DTCs");
-        verify(mockListener, times(2)).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                                  "6.1.19.2.b - Fail if any ECU does not report MIL off");
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                        "6.1.19.4.a Fail if any difference compared to data received during global request");
+                                                  "6.1.19.2.a - An ECU reported active DTCs");
+        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
+                                                  "6.1.19.2.b - An ECU did not report MIL off");
+        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
+                                        "6.1.19.4.a - Difference compared to data received during global request");
 
-        String expectedResults = "FAIL: 6.1.19.2.a - Fail if any ECU reports active DTCs" + NL;
-        expectedResults += "FAIL: 6.1.19.2.b - Fail if any ECU does not report MIL off" + NL;
-        expectedResults += "FAIL: 6.1.19.2.a - Fail if any ECU reports active DTCs" + NL;
-        expectedResults += "FAIL: 6.1.19.2.b - Fail if any ECU does not report MIL off" + NL;
-        expectedResults += "FAIL: 6.1.19.4.a Fail if any difference compared to data received during global request"
-                + NL;
+        String expectedResults = "FAIL: 6.1.19.2.a - An ECU reported active DTCs" + NL;
+        expectedResults += "FAIL: 6.1.19.2.b - An ECU did not report MIL off" + NL;
+        expectedResults += "FAIL: 6.1.19.4.a - Difference compared to data received during global request" + NL;
 
         assertEquals(expectedResults, listener.getResults());
     }
@@ -257,15 +234,14 @@ public class Step19ControllerTest extends AbstractControllerTest {
                 Packet.create(PGN, 0x03, 0x11, 0x22, (byte) 0x0A, 0x44, 0x55, 0x66, 0x77,
                               0x88));
 
-        List<Integer> obdModuleAddresses = Arrays.asList(0x01, 0x03);
+        List<Integer> obdModuleAddresses = List.of(0x01, 0x03);
         when(dataRepository.getObdModuleAddresses()).thenReturn(obdModuleAddresses);
 
         DM23PreviouslyMILOnEmissionDTCPacket packet3b = new DM23PreviouslyMILOnEmissionDTCPacket(
                 Packet.create(PGN, 0x03, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF));
 
         when(dtcModule.requestDM23(any(), eq(true)))
-                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet3),
-                                                Collections.singletonList(ackPacket)));
+                .thenReturn(new RequestResult<>(false, List.of(packet3), List.of(ackPacket)));
         when(dtcModule.requestDM23(any(), eq(true), eq(0x01)))
                 .thenReturn(new BusResult<>(false, packet1));
         when(dtcModule.requestDM23(any(), eq(true), eq(0x03)))
@@ -280,19 +256,19 @@ public class Step19ControllerTest extends AbstractControllerTest {
         verify(dtcModule).requestDM23(any(), eq(true), eq(0x03));
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                        "6.1.19.2.a - Fail if any ECU reports active DTCs");
+                                        "6.1.19.2.a - An ECU reported active DTCs");
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                        "6.1.19.2.b - Fail if any ECU does not report MIL off");
+                                        "6.1.19.2.b - An ECU did not report MIL off");
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                        "6.1.19.4.a Fail if any difference compared to data received during global request");
+                                        "6.1.19.4.a - Difference compared to data received during global request");
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                        "6.1.19.4.b Fail if NACK not received from OBD ECUs that did not respond to global query");
+                                        "6.1.19.4.b - OBD module Engine #2 (1) did not provide a response to Global query and did not provide a NACK for the DS query");
 
-        String expectedResults = "FAIL: 6.1.19.2.a - Fail if any ECU reports active DTCs" + NL;
-        expectedResults += "FAIL: 6.1.19.2.b - Fail if any ECU does not report MIL off" + NL;
-        expectedResults += "FAIL: 6.1.19.4.a Fail if any difference compared to data received during global request"
+        String expectedResults = "FAIL: 6.1.19.2.a - An ECU reported active DTCs" + NL;
+        expectedResults += "FAIL: 6.1.19.2.b - An ECU did not report MIL off" + NL;
+        expectedResults += "FAIL: 6.1.19.4.a - Difference compared to data received during global request"
                 + NL;
-        expectedResults += "FAIL: 6.1.19.4.b Fail if NACK not received from OBD ECUs that did not respond to global query"
+        expectedResults += "FAIL: 6.1.19.4.b - OBD module Engine #2 (1) did not provide a response to Global query and did not provide a NACK for the DS query"
                 + NL;
 
         assertEquals(expectedResults, listener.getResults());
@@ -311,11 +287,11 @@ public class Step19ControllerTest extends AbstractControllerTest {
         DM23PreviouslyMILOnEmissionDTCPacket packet1 = new DM23PreviouslyMILOnEmissionDTCPacket(
                 Packet.create(PGN, 0x01, 0x00, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00));
 
-        List<Integer> obdModuleAddresses = Collections.singletonList(0x01);
+        List<Integer> obdModuleAddresses = List.of(0x01);
         when(dataRepository.getObdModuleAddresses()).thenReturn(obdModuleAddresses);
 
         when(dtcModule.requestDM23(any(), eq(true)))
-                .thenReturn(new RequestResult<>(false, Collections.singletonList(packet1), Collections.emptyList()));
+                .thenReturn(new RequestResult<>(false, List.of(packet1), List.of()));
         when(dtcModule.requestDM23(any(), eq(true), eq(0x01)))
                 .thenReturn(new BusResult<>(false, packet1));
 

--- a/src-test/org/etools/j1939_84/controllers/part1/Step20ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Step20ControllerTest.java
@@ -5,11 +5,9 @@ package org.etools.j1939_84.controllers.part1;
 
 import static org.etools.j1939_84.J1939_84.NL;
 import static org.etools.j1939_84.model.Outcome.FAIL;
-import static org.etools.j1939_84.model.Outcome.WARN;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -139,17 +137,11 @@ public class Step20ControllerTest extends AbstractControllerTest {
                                         "6.1.20.2.c - No OBD ECU provided a DM28");
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
-                                        WARN,
-                                        "6.1.20.3 OBD module Engine #2 (1) did not return a response to a destination specific request");
-        verify(mockListener).addOutcome(PART_NUMBER,
-                                        STEP_NUMBER,
-                                        WARN,
-                                        "6.1.20.3.a Destination Specific DM28 requests to OBD modules did not return any responses");
+                                        FAIL,
+                                        "6.1.20.4.b - OBD module Engine #2 (1) did not provide a response to Global query and did not provide a NACK for the DS query");
 
         String expectedResults = "FAIL: 6.1.20.2.c - No OBD ECU provided a DM28" + NL;
-        expectedResults += "WARN: 6.1.20.3 OBD module Engine #2 (1) did not return a response to a destination specific request"
-                + NL;
-        expectedResults += "WARN: 6.1.20.3.a Destination Specific DM28 requests to OBD modules did not return any responses"
+        expectedResults += "FAIL: 6.1.20.4.b - OBD module Engine #2 (1) did not provide a response to Global query and did not provide a NACK for the DS query"
                 + NL;
         assertEquals(expectedResults, listener.getResults());
         assertEquals("", listener.getMessages());
@@ -189,18 +181,16 @@ public class Step20ControllerTest extends AbstractControllerTest {
         verify(dtcModule).requestDM28(any(), eq(true), eq(0x01));
         verify(dtcModule).requestDM28(any(), eq(true), eq(0x03));
 
-        verify(mockListener, times(2)).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
+        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
                                                   "6.1.20.2.a - An ECU reported permanent DTCs");
-        verify(mockListener, times(2)).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
+        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
                                                   "6.1.20.2.b - An ECU did not report MIL off");
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                        "6.1.20.4.a Difference compared to data received during global request");
+                                        "6.1.20.4.a - Difference compared to data received during global request");
 
         String expectedResults = "FAIL: 6.1.20.2.a - An ECU reported permanent DTCs" + NL;
         expectedResults += "FAIL: 6.1.20.2.b - An ECU did not report MIL off" + NL;
-        expectedResults += "FAIL: 6.1.20.2.a - An ECU reported permanent DTCs" + NL;
-        expectedResults += "FAIL: 6.1.20.2.b - An ECU did not report MIL off" + NL;
-        expectedResults += "FAIL: 6.1.20.4.a Difference compared to data received during global request" + NL;
+        expectedResults += "FAIL: 6.1.20.4.a - Difference compared to data received during global request" + NL;
 
         assertEquals(expectedResults, listener.getResults());
     }
@@ -276,16 +266,16 @@ public class Step20ControllerTest extends AbstractControllerTest {
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
                                         "6.1.20.2.b - An ECU did not report MIL off");
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                        "6.1.20.4.a Difference compared to data received during global request");
+                                        "6.1.20.4.a - Difference compared to data received during global request");
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
-                                        "6.1.20.4.b NACK not received from OBD ECUs that did not respond to global query");
+                                        "6.1.20.4.b - OBD module Engine #2 (1) did not provide a response to Global query and did not provide a NACK for the DS query");
 
         String expectedResults = "FAIL: 6.1.20.2.a - An ECU reported permanent DTCs" + NL;
         expectedResults += "FAIL: 6.1.20.2.b - An ECU did not report MIL off" + NL;
-        expectedResults += "FAIL: 6.1.20.4.a Difference compared to data received during global request" + NL;
-        expectedResults += "FAIL: 6.1.20.4.b NACK not received from OBD ECUs that did not respond to global query" + NL;
+        expectedResults += "FAIL: 6.1.20.4.a - Difference compared to data received during global request" + NL;
+        expectedResults += "FAIL: 6.1.20.4.b - OBD module Engine #2 (1) did not provide a response to Global query and did not provide a NACK for the DS query" + NL;
 
         assertEquals(expectedResults, listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part1/Step23ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Step23ControllerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2020 Equipment & Tool Institute
+/*
+ * Copyright 2021 Equipment & Tool Institute
  */
 package org.etools.j1939_84.controllers.part1;
 
@@ -73,11 +73,8 @@ public class Step23ControllerTest extends AbstractControllerTest {
     @Mock
     private VehicleInformationModule vehicleInformationModule;
 
-    /**
-     * @throws java.lang.Exception
-     */
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         listener = new TestResultsListener(mockListener);
         DateTimeModule.setInstance(null);
 
@@ -92,11 +89,8 @@ public class Step23ControllerTest extends AbstractControllerTest {
         setup(instance, listener, j1939, engineSpeedModule, reportFileModule, executor, vehicleInformationModule);
     }
 
-    /**
-     * @throws java.lang.Exception
-     */
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         verifyNoMoreInteractions(executor,
                                  engineSpeedModule,
                                  bannerModule,
@@ -132,9 +126,9 @@ public class Step23ControllerTest extends AbstractControllerTest {
         verify(dtcModule).requestDM31(any());
 
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL,
-                                                       "6.1.23.2 - a. Fail if any received ECU response does not report MIL off");
+                                                       "6.1.23.2.a - An ECU response does not report MIL off");
 
-        String expectedResults = "FAIL: 6.1.23.2 - a. Fail if any received ECU response does not report MIL off" + NL;
+        String expectedResults = "FAIL: 6.1.23.2.a - An ECU response does not report MIL off" + NL;
         assertEquals(expectedResults, listener.getResults());
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getMilestones());

--- a/src-test/org/etools/j1939_84/controllers/part1/Step24ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Step24ControllerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2020 Equipment & Tool Institute
+/*
+ * Copyright 2021 Equipment & Tool Institute
  */
 package org.etools.j1939_84.controllers.part1;
 
@@ -81,11 +81,8 @@ public class Step24ControllerTest extends AbstractControllerTest {
     @Mock
     private VehicleInformationModule vehicleInformationModule;
 
-    /**
-     * @throws java.lang.Exception
-     */
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         listener = new TestResultsListener(mockListener);
         DateTimeModule.setInstance(null);
 
@@ -100,11 +97,8 @@ public class Step24ControllerTest extends AbstractControllerTest {
         setup(instance, listener, j1939, engineSpeedModule, reportFileModule, executor, vehicleInformationModule);
     }
 
-    /**
-     * @throws java.lang.Exception
-     */
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         verifyNoMoreInteractions(executor,
                                  engineSpeedModule,
                                  bannerModule,
@@ -150,9 +144,9 @@ public class Step24ControllerTest extends AbstractControllerTest {
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
                                                        FAIL,
-                                                       "6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]");
+                                                       "6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored");
 
-        String expectedResults = "FAIL: 6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]"
+        String expectedResults = "FAIL: 6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored"
                 + NL;
         assertEquals(expectedResults, listener.getResults());
         assertEquals("", listener.getMessages());
@@ -194,9 +188,9 @@ public class Step24ControllerTest extends AbstractControllerTest {
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
                                                        FAIL,
-                                                       "6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]");
+                                                       "6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored");
 
-        String expectedResults = "FAIL: 6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]"
+        String expectedResults = "FAIL: 6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored"
                 + NL;
         assertEquals(expectedResults, listener.getResults());
         assertEquals("", listener.getMessages());
@@ -238,9 +232,9 @@ public class Step24ControllerTest extends AbstractControllerTest {
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
                                                        FAIL,
-                                                       "6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]");
+                                                       "6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored");
 
-        String expectedResults = "FAIL: 6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]"
+        String expectedResults = "FAIL: 6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored"
                 + NL;
         assertEquals(expectedResults, listener.getResults());
         assertEquals("", listener.getMessages());
@@ -282,9 +276,9 @@ public class Step24ControllerTest extends AbstractControllerTest {
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
                                                        FAIL,
-                                                       "6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]");
+                                                       "6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored");
 
-        String expectedResults = "FAIL: 6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]"
+        String expectedResults = "FAIL: 6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored"
                 + NL;
         assertEquals(expectedResults, listener.getResults());
         assertEquals("", listener.getMessages());
@@ -326,9 +320,9 @@ public class Step24ControllerTest extends AbstractControllerTest {
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
                                                        FAIL,
-                                                       "6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]");
+                                                       "6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored");
 
-        String expectedResults = "FAIL: 6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]"
+        String expectedResults = "FAIL: 6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored"
                 + NL;
         assertEquals(expectedResults, listener.getResults());
         assertEquals("", listener.getMessages());
@@ -370,9 +364,9 @@ public class Step24ControllerTest extends AbstractControllerTest {
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
                                                        FAIL,
-                                                       "6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]");
+                                                       "6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored");
 
-        String expectedResults = "FAIL: 6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]"
+        String expectedResults = "FAIL: 6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored"
                 + NL;
         assertEquals(expectedResults, listener.getResults());
         assertEquals("", listener.getMessages());
@@ -414,9 +408,9 @@ public class Step24ControllerTest extends AbstractControllerTest {
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
                                                        FAIL,
-                                                       "6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]");
+                                                       "6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored");
 
-        String expectedResults = "FAIL: 6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]"
+        String expectedResults = "FAIL: 6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored"
                 + NL;
         assertEquals(expectedResults, listener.getResults());
         assertEquals("", listener.getMessages());
@@ -458,9 +452,9 @@ public class Step24ControllerTest extends AbstractControllerTest {
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
                                                        FAIL,
-                                                       "6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]");
+                                                       "6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored");
 
-        String expectedResults = "FAIL: 6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]"
+        String expectedResults = "FAIL: 6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored"
                 + NL;
         assertEquals(expectedResults, listener.getResults());
         assertEquals("", listener.getMessages());
@@ -502,9 +496,9 @@ public class Step24ControllerTest extends AbstractControllerTest {
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
                                                        FAIL,
-                                                       "6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]");
+                                                       "6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored");
 
-        String expectedResults = "FAIL: 6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]"
+        String expectedResults = "FAIL: 6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored"
                 + NL;
         assertEquals(expectedResults, listener.getResults());
         assertEquals("", listener.getMessages());
@@ -546,9 +540,9 @@ public class Step24ControllerTest extends AbstractControllerTest {
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
                                                        FAIL,
-                                                       "6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]");
+                                                       "6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored");
 
-        String expectedResults = "FAIL: 6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]"
+        String expectedResults = "FAIL: 6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored"
                 + NL;
         assertEquals(expectedResults, listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src/org/etools/j1939_84/controllers/StepController.java
+++ b/src/org/etools/j1939_84/controllers/StepController.java
@@ -3,7 +3,21 @@
  */
 package org.etools.j1939_84.controllers;
 
+import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response.NACK;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+import org.etools.j1939_84.bus.j1939.BusResult;
+import org.etools.j1939_84.bus.j1939.Lookup;
+import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
+import org.etools.j1939_84.bus.j1939.packets.GenericPacket;
+import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
+import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
@@ -53,4 +67,73 @@ public abstract class StepController extends Controller {
     public int getTotalSteps() {
         return totalSteps;
     }
+
+    protected void compareRequestPackets(List<? extends GenericPacket> globalPackets,
+                                         List<? extends GenericPacket> dsPackets,
+                                         String section) {
+        for (GenericPacket globalPacket : globalPackets) {
+            Optional<? extends GenericPacket> dsOptional = dsPackets.stream()
+                    .filter(dsPacket -> dsPacket.getSourceAddress() == globalPacket.getSourceAddress())
+                    .findFirst();
+
+            if (dsOptional.isPresent()) {
+                byte[] dsBytes = dsOptional.get().getPacket().getBytes();
+                byte[] globalBytes = globalPacket.getPacket().getBytes();
+                if (!Arrays.equals(dsBytes, globalBytes)) {
+                    addFailure(section + " - Difference compared to data received during global request");
+                    break; //Only report the error once
+                }
+            }
+        }
+    }
+
+    protected void checkForNACKs(List<? extends GenericPacket> globalPackets,
+                                 List<? extends AcknowledgmentPacket> dsAcks,
+                                 Collection<Integer> obdModuleAddresses,
+                                 String section) {
+        List<Integer> addresses = new ArrayList<>(obdModuleAddresses);
+
+        globalPackets
+                .stream()
+                .map(ParsedPacket::getSourceAddress)
+                .forEach(addresses::remove);
+
+        dsAcks
+                .stream()
+                .filter(ack -> ack.getResponse() == NACK)
+                .map(ParsedPacket::getSourceAddress)
+                .forEach(addresses::remove);
+
+        addresses.stream()
+                .distinct()
+                .sorted()
+                .map(address -> section + " - OBD module " + Lookup.getAddressName(address) + " did not provide a response to Global query and did not provide a NACK for the DS query")
+                .forEach(this::addFailure);
+    }
+
+    protected static <T extends GenericPacket> List<T> filterRequestResultPackets(List<RequestResult<T>> results) {
+        return results.stream().flatMap(r -> r.getPackets().stream()).collect(Collectors.toList());
+    }
+
+    protected static <T extends GenericPacket> List<AcknowledgmentPacket> filterRequestResultAcks(List<RequestResult<T>> results) {
+        return results.stream().flatMap(r -> r.getAcks().stream()).collect(Collectors.toList());
+    }
+
+    protected static <T extends GenericPacket> List<T> filterPackets(List<BusResult<T>> results) {
+        return results.stream()
+                .map(BusResult::requestResult)
+                .flatMap(r -> r.getPackets().stream())
+                .collect(Collectors.toList());
+    }
+
+    protected static <T extends GenericPacket> List<AcknowledgmentPacket> filterAcks(List<BusResult<T>> results) {
+        return results.stream()
+                .map(BusResult::getPacket)
+                .filter(Optional::isPresent)
+                .map(p -> p.get().right)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/org/etools/j1939_84/controllers/part1/Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step07Controller.java
@@ -169,8 +169,6 @@ public class Step07Controller extends StepController {
                         addFailure(PART_NUMBER, STEP_NUMBER, "6.1.7.3.c.iv Received CVN is all 0x00");
                     }
                 }
-                // TODO 6.1.7.2.b.iv. Fail if CVN padded incorrectly (must use 0x00 in MSB for unused bytes)
-                // TODO 6.1.7.3.c.v. Warn if CVN padded incorrectly (must use 0x00 in MSB for unused bytes)
             }
         }
 

--- a/src/org/etools/j1939_84/controllers/part1/Step11Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step11Controller.java
@@ -3,24 +3,26 @@
  */
 package org.etools.j1939_84.controllers.part1;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import org.etools.j1939_84.bus.j1939.BusResult;
-import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response;
+import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM21DiagnosticReadinessPacket;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
-import org.etools.j1939_84.modules.*;
+import org.etools.j1939_84.modules.BannerModule;
+import org.etools.j1939_84.modules.DateTimeModule;
+import org.etools.j1939_84.modules.DiagnosticReadinessModule;
+import org.etools.j1939_84.modules.EngineSpeedModule;
+import org.etools.j1939_84.modules.VehicleInformationModule;
 
 /**
  * @author Marianne Schaefer (marianne.m.schaefer@gmail.com)
  * <p>
  * The controller for 6.1.11 DM21: Diagnostic readiness 2
  */
-
 public class Step11Controller extends StepController {
 
     private static final int PART_NUMBER = 1;
@@ -37,7 +39,7 @@ public class Step11Controller extends StepController {
              new DiagnosticReadinessModule(),
              new VehicleInformationModule(),
              dataRepository,
-                DateTimeModule.getInstance());
+             DateTimeModule.getInstance());
     }
 
     Step11Controller(Executor executor,
@@ -63,115 +65,110 @@ public class Step11Controller extends StepController {
     protected void run() throws Throwable {
         diagnosticReadinessModule.setJ1939(getJ1939());
         // 6.1.11.1.a. Global DM21 (send Request (PGN 59904) for PGN 49408
-        List<DM21DiagnosticReadinessPacket> globalDm21Packets = diagnosticReadinessModule
+        List<DM21DiagnosticReadinessPacket> globalPackets = diagnosticReadinessModule
                 .requestDM21Packets(getListener(), true).getPackets();
 
-        globalDm21Packets.forEach(packet -> {
-            // 6.1.11.2.a. Fail if any ECU reports distance with MIL on (SPN 3069) is not zero.
-            if (packet.getKmSinceDTCsCleared() != 0 || packet.getMilesSinceDTCsCleared() != 0) {
-                addFailure(1,
-                           11,
-                           "6.1.11.1.a - An ECU reported distance with MIL on (SPN 3069) is not zero");
-            }
-            // 6.1.11.2.b. Fail if any ECU reports distance SCC (SPN 3294) is not zero.
-            if (packet.getKmWhileMILIsActivated() != 0 || packet.getMilesWhileMILIsActivated() != 0) {
-                addFailure(1,
-                           11,
-                           "6.1.11.1.b - An ECU reported distance SCC (SPN 3294) is not zero");
-            }
-            // 6.1.11.2.c. Fail if any ECU reports time with MIL on (SPN 3295) is not zero (if supported)
-            if (packet.getMinutesWhileMILIsActivated() != 0) {
-                addFailure(1,
-                           11,
-                           "6.1.11.1.c - An ECU reported time with MIL on (SPN 3295) is not zero");
-            }
-            // 6.1.11.2.d. Fail if any ECU reports time SCC (SPN 3296) > 1 minute (if supported).
-            if (packet.getMinutesSinceDTCsCleared() > 1) {
-                addFailure(1,
-                           11,
-                           "6.1.11.1.d - An ECU reported time SCC (SPN 3296) > 1 minute");
-            }
-        });
         // 6.1.11.2.e. Fail if no OBD ECU provides a DM21 message.
-        if (globalDm21Packets.isEmpty()) {
+        if (globalPackets.isEmpty()) {
             addFailure(1, 11, "6.1.11.1.e - No OBD ECU provided a DM21 message");
+        } else {
+            for (DM21DiagnosticReadinessPacket packet : globalPackets) {
+                // 6.1.11.2.a. Fail if any ECU reports distance with MIL on (SPN 3069) is not zero.
+                if (packet.getKmSinceDTCsCleared() != 0 || packet.getMilesSinceDTCsCleared() != 0) {
+                    addFailure(1,
+                               11,
+                               "6.1.11.1.a - An ECU reported distance with MIL on (SPN 3069) is not zero");
+                    break;
+                }
+            }
+
+            for (DM21DiagnosticReadinessPacket packet : globalPackets) {
+                // 6.1.11.2.b. Fail if any ECU reports distance SCC (SPN 3294) is not zero.
+                if (packet.getKmWhileMILIsActivated() != 0 || packet.getMilesWhileMILIsActivated() != 0) {
+                    addFailure(1,
+                               11,
+                               "6.1.11.1.b - An ECU reported distance SCC (SPN 3294) is not zero");
+                    break;
+                }
+            }
+
+            for (DM21DiagnosticReadinessPacket packet : globalPackets) {
+                // 6.1.11.2.c. Fail if any ECU reports time with MIL on (SPN 3295) is not zero (if supported)
+                if (packet.getMinutesWhileMILIsActivated() != 0) {
+                    addFailure(1,
+                               11,
+                               "6.1.11.1.c - An ECU reported time with MIL on (SPN 3295) is not zero");
+                    break;
+                }
+            }
+
+            for (DM21DiagnosticReadinessPacket packet : globalPackets) {
+                // 6.1.11.2.d. Fail if any ECU reports time SCC (SPN 3296) > 1 minute (if supported).
+                if (packet.getMinutesSinceDTCsCleared() > 1) {
+                    addFailure(1,
+                               11,
+                               "6.1.11.1.d - An ECU reported time SCC (SPN 3296) > 1 minute");
+                    break;
+                }
+            }
         }
 
         // 6.1.11.3.a. DS DM21 to each OBD ECU
-        List<BusResult<DM21DiagnosticReadinessPacket>> addressSpecificDM21Results = dataRepository
-                .getObdModuleAddresses().stream()
+        List<Integer> obdModuleAddresses = dataRepository.getObdModuleAddresses();
+
+        List<BusResult<DM21DiagnosticReadinessPacket>> dsResults = obdModuleAddresses
+                .stream()
                 .map(addr -> diagnosticReadinessModule.getDM21Packets(getListener(), true, addr))
                 .collect(Collectors.toList());
 
         // ignore missing responses and NACKs
-        List<DM21DiagnosticReadinessPacket> addressSpecificDm21Packets = addressSpecificDM21Results.stream()
-                .flatMap(r -> r.getPacket().stream())
-                .flatMap(r -> r.left.stream())
-                .collect(Collectors.toList());
-        addressSpecificDm21Packets
-                .forEach(packet -> {
-                    // 6.1.11.4.a. Fail if any ECU reports distance with MIL on (SPN 3069) is not zero.
-                    if (packet.getKmSinceDTCsCleared() != 0 || packet.getMilesSinceDTCsCleared() != 0) {
-                        addFailure(1,
-                                   11,
-                                   "6.1.11.4.a - An ECU reported distance with MIL on (SPN 3069) is not zero");
-                    }
-                    // 6.1.11.4.b. Fail if any ECU reports distance SCC (SPN 3294) is not zero.
-                    if (packet.getKmWhileMILIsActivated() != 0 || packet.getMilesWhileMILIsActivated() != 0) {
-                        addFailure(1,
-                                   11,
-                                   "6.1.11.4.b. - An ECU reported distance SCC (SPN 3294) is not zero");
-                    }
-                    // 6.1.11.4.c. Fail if any ECU reports time with MIL on (SPN 3295) is not zero (if supported)
-                    if (packet.getMinutesWhileMILIsActivated() != 0) {
-                        addFailure(1,
-                                   11,
-                                   "6.1.11.4.c - An ECU reported time with MIL on (SPN 3295) is not zero");
-                    }
-                    // 6.1.11.4.d. Fail if any ECU reports time SCC (SPN 3296) > 1 minute (if supported).
-                    if (packet.getMinutesSinceDTCsCleared() != 0) {
-                        addFailure(1,
-                                   11,
-                                   "6.1.11.4.d - An ECU reported time SCC (SPN 3296) > 1 minute");
-                    }
-                });
-
-        // 6.1.11.4.e. Fail if any responses differ from global responses.
-        List<DM21DiagnosticReadinessPacket> results = new ArrayList<>();
-
-        if (addressSpecificDm21Packets.size() > globalDm21Packets.size()) {
-            results.addAll(addressSpecificDm21Packets);
-            results.removeAll(globalDm21Packets);
-        } else {
-            results.addAll(globalDm21Packets);
-            results.removeAll(addressSpecificDm21Packets);
+        List<DM21DiagnosticReadinessPacket> dsPackets = filterPackets(dsResults);
+        for (DM21DiagnosticReadinessPacket packet : dsPackets) {
+            // 6.1.11.4.a. Fail if any ECU reports distance with MIL on (SPN 3069) is not zero.
+            if (packet.getKmSinceDTCsCleared() != 0 || packet.getMilesSinceDTCsCleared() != 0) {
+                addFailure(1,
+                           11,
+                           "6.1.11.4.a - An ECU reported distance with MIL on (SPN 3069) is not zero");
+                break;
+            }
         }
 
-        if (!results.isEmpty()) {
-            addFailure(1,
-                       11,
-                       "6.1.11.4.e - DS responses differ from global responses");
+        for (DM21DiagnosticReadinessPacket packet : dsPackets) {
+            // 6.1.11.4.b. Fail if any ECU reports distance SCC (SPN 3294) is not zero.
+            if (packet.getKmWhileMILIsActivated() != 0 || packet.getMilesWhileMILIsActivated() != 0) {
+                addFailure(1,
+                           11,
+                           "6.1.11.4.b - An ECU reported distance SCC (SPN 3294) is not zero");
+                break;
+            }
         }
 
-        // 6.1.11.4.f. Fail if NACK not received from OBD ECUs that did not respond to global query.
-        addressSpecificDm21Packets.forEach(addressPacket -> globalDm21Packets
-                .removeIf(globalPacket -> globalPacket.getSourceAddress() == addressPacket.getSourceAddress()));
-
-        addressSpecificDM21Results.stream()
-                // for each bus result
-                .flatMap(br -> br.getPacket().stream())
-                // only consider the NACKs
-                .flatMap(e -> e.right.stream())
-                .filter(a -> a.getResponse() == Response.NACK)
-                .forEach(nackPacket -> globalDm21Packets
-                        .removeIf(globalPacket -> globalPacket.getSourceAddress() == nackPacket.getSourceAddress()));
-
-        if (!globalDm21Packets.isEmpty()) {
-            addFailure(1,
-                       11,
-                       "6.1.11.4.f - NACK not received from OBD ECUs that did not respond to global query");
+        for (DM21DiagnosticReadinessPacket packet : dsPackets) {
+            // 6.1.11.4.c. Fail if any ECU reports time with MIL on (SPN 3295) is not zero (if supported)
+            if (packet.getMinutesWhileMILIsActivated() != 0) {
+                addFailure(1,
+                           11,
+                           "6.1.11.4.c - An ECU reported time with MIL on (SPN 3295) is not zero");
+                break;
+            }
         }
 
+        for (DM21DiagnosticReadinessPacket packet : dsPackets) {
+            // 6.1.11.4.d. Fail if any ECU reports time SCC (SPN 3296) > 1 minute (if supported).
+            if (packet.getMinutesSinceDTCsCleared() != 0) {
+                addFailure(1,
+                           11,
+                           "6.1.11.4.d - An ECU reported time SCC (SPN 3296) > 1 minute");
+                break;
+            }
+        }
+
+        // 6.1.11.4.e Fail if any difference compared to data received during global request.
+        compareRequestPackets(globalPackets, dsPackets, "6.1.11.4.e");
+
+        // 6.1.11.4.f Fail if NACK not received from OBD ECUs that did not respond to global query.
+        List<AcknowledgmentPacket> dsAcks = filterAcks(dsResults);
+        checkForNACKs(globalPackets, dsAcks, obdModuleAddresses, "6.1.11.4.f");
     }
 
 }

--- a/src/org/etools/j1939_84/controllers/part1/Step16Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step16Controller.java
@@ -1,28 +1,29 @@
-/**
+/*
  * Copyright 2020 Equipment & Tool Institute
  */
 package org.etools.j1939_84.controllers.part1;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
-import org.etools.j1939_84.bus.Either;
+import org.etools.j1939_84.bus.j1939.BusResult;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
-import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response;
 import org.etools.j1939_84.bus.j1939.packets.DM2PreviouslyActiveDTC;
+import org.etools.j1939_84.bus.j1939.packets.DiagnosticTroubleCodePacket;
 import org.etools.j1939_84.bus.j1939.packets.LampStatus;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
-import org.etools.j1939_84.model.Outcome;
 import org.etools.j1939_84.model.RequestResult;
-import org.etools.j1939_84.modules.*;
+import org.etools.j1939_84.modules.BannerModule;
+import org.etools.j1939_84.modules.DTCModule;
+import org.etools.j1939_84.modules.DateTimeModule;
+import org.etools.j1939_84.modules.EngineSpeedModule;
+import org.etools.j1939_84.modules.VehicleInformationModule;
 
 /**
  * @author Garrison Garland {garrison@soliddesign.net)
  */
-
 public class Step16Controller extends StepController {
 
     private static final int PART_NUMBER = 1;
@@ -40,7 +41,7 @@ public class Step16Controller extends StepController {
              new VehicleInformationModule(),
              new DTCModule(),
              dataRepository,
-                DateTimeModule.getInstance());
+             DateTimeModule.getInstance());
     }
 
     protected Step16Controller(Executor executor,
@@ -67,86 +68,47 @@ public class Step16Controller extends StepController {
     protected void run() throws Throwable {
 
         dtcModule.setJ1939(getJ1939());
-        // 6.1.16.1 Actions:
-        // a. Global DM2 (send Request (PGN 59904) for PGN 65227 (SPNs
-        // 1213-1215, 3038, 1706)).
-        RequestResult<DM2PreviouslyActiveDTC> globalDiagnosticTroubleCodePackets = dtcModule.requestDM2(getListener(),
-                                                                                                        true);
 
-        // Get DM2PrevisoulyActiveDTC so we can get DTCs and report accordingly
-        List<DM2PreviouslyActiveDTC> globalDM2s = globalDiagnosticTroubleCodePackets.getPackets();
+        // 6.1.16.1.a. Global DM2 (send Request (PGN 59904) for PGN 65227 (SPNs 1213-1215, 3038, 1706))
+        RequestResult<DM2PreviouslyActiveDTC> globalResults = dtcModule.requestDM2(getListener(), true);
+
+        // Get DM2PreviouslyActiveDTC so we can get DTCs and report accordingly
+        List<DM2PreviouslyActiveDTC> globalPackets = globalResults.getPackets();
 
         // 6.1.16.2.a Fail if any OBD ECU reports a previously active DTC.
-        if (globalDM2s.stream().flatMap(packet -> packet.getDtcs().stream()).findAny().isPresent()) {
-            getListener().addOutcome(1,
-                                     16,
-                                     Outcome.FAIL,
-                                     "6.1.16.2.a - OBD ECU reported a previously active DTC");
+        boolean hasDTC = globalPackets.stream().flatMap(packet -> packet.getDtcs().stream()).findAny().isPresent();
+        if (hasDTC) {
+            addFailure("6.1.16.2.a - OBD ECU reported a previously active DTC");
         }
 
-        // 6.1.16.2.b Fail if any OBD ECU does not report MIL (Malfunction
-        // Indicator Lamp) off
-        if (globalDM2s.stream().filter(packet -> packet.getMalfunctionIndicatorLampStatus() != LampStatus.OFF).findAny()
-                .isPresent()) {
-            getListener().addOutcome(1,
-                                     16,
-                                     Outcome.FAIL,
-                                     "6.1.16.2.b - OBD ECU does not report MIL off");
+        // 6.1.16.2.b Fail if any OBD ECU does not report MIL (Malfunction Indicator Lamp) off
+        boolean isMilOn = globalPackets.stream()
+                .anyMatch(packet -> packet.getMalfunctionIndicatorLampStatus() != LampStatus.OFF);
+        if (isMilOn) {
+            addFailure("6.1.16.2.b - OBD ECU does not report MIL off");
         }
 
-        // 6.1.16.2.c Fail if any non-OBD ECU does not report MIL off or not
-        // supported - LampStatus of OTHER
+        // 6.1.16.2.c Fail if any non-OBD ECU does not report MIL off or not supported - LampStatus of OTHER
         List<Integer> obdAddresses = dataRepository.getObdModuleAddresses();
-        if (globalDM2s.stream()
+        boolean isMilWrong = globalPackets.stream()
                 .filter(p -> !obdAddresses.contains(p.getSourceAddress()))
-                .filter(p -> p.getMalfunctionIndicatorLampStatus() != LampStatus.OFF
-                        && p.getMalfunctionIndicatorLampStatus() != LampStatus.OTHER)
-                .findAny()
-                .isPresent()) {
-            getListener().addOutcome(1,
-                                     16,
-                                     Outcome.FAIL,
-                                     "6.1.16.2.c - non-OBD ECU does not report MIL off or not supported");
+                .map(DiagnosticTroubleCodePacket::getMalfunctionIndicatorLampStatus)
+                .anyMatch(mil -> mil != LampStatus.OFF && mil != LampStatus.OTHER);
+        if (isMilWrong) {
+            addFailure("6.1.16.2.c - Non-OBD ECU does not report MIL off or not supported");
         }
 
         // 6.1.16.3.a DS DM2 to each OBD ECU
-        List<Either<DM2PreviouslyActiveDTC, AcknowledgmentPacket>> dsResult = obdAddresses.stream()
-                .flatMap(address -> dtcModule.requestDM2(getListener(), true, address).getPacket().stream())
-                .collect(Collectors.toList());
-
-        List<DM2PreviouslyActiveDTC> dsDM2s = dsResult.stream().filter(r -> r.left.isPresent()).map(p -> p.left.get())
-                .collect(Collectors.toList());
-
-        List<DM2PreviouslyActiveDTC> unmatchedPackets = globalDiagnosticTroubleCodePackets.getPackets().stream()
-                .filter(packet -> !dsDM2s.contains(packet))
+        List<BusResult<DM2PreviouslyActiveDTC>> dsResult = obdAddresses.stream()
+                .map(address -> dtcModule.requestDM2(getListener(), true, address))
                 .collect(Collectors.toList());
 
         // 6.1.16.4.a Fail if any responses differ from global responses
-        if (!unmatchedPackets.isEmpty()) {
-            getListener().addOutcome(1,
-                                     16,
-                                     Outcome.FAIL,
-                                     "6.1.16.4.a DS DM2 responses differ from global responses");
-        }
+        List<DM2PreviouslyActiveDTC> dsDM2s = filterPackets(dsResult);
+        compareRequestPackets(globalPackets, dsDM2s, "6.1.16.4.a");
 
-        Collection<Integer> responseAddresses = globalDM2s.stream().map(p -> p.getSourceAddress())
-                .collect(Collectors.toSet());
-        obdAddresses.removeAll(responseAddresses);
-
-        // 6.1.16.4.b Fail if NACK not received from OBD ECUs that did not
-        // respond to global query
-        Collection<Integer> nackAddresses = dsResult.stream()
-                .filter(r -> r.right.isPresent())
-                .map(r -> r.right.get())
-                .filter(packet -> packet.getResponse() == Response.NACK).map(p -> p.getSourceAddress())
-                .collect(Collectors.toSet());
-        obdAddresses.removeAll(nackAddresses);
-
-        if (!obdAddresses.isEmpty()) {
-            getListener().addOutcome(1,
-                                     16,
-                                     Outcome.FAIL,
-                                     "6.1.16.4.b Nack not received from OBD ECUs that did not respond to global query");
-        }
+        // 6.1.16.4.b Fail if NACK not received from OBD ECUs that did not respond to global query
+        List<AcknowledgmentPacket> dsAcks = filterAcks(dsResult);
+        checkForNACKs(globalPackets, dsAcks, obdAddresses, "6.1.16.4.b");
     }
 }

--- a/src/org/etools/j1939_84/controllers/part1/Step17Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step17Controller.java
@@ -1,19 +1,23 @@
-/**
- * Copyright 2020 Equipment & Tool Institute
+/*
+ * Copyright 2021 Equipment & Tool Institute
  */
 package org.etools.j1939_84.controllers.part1;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
+import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM6PendingEmissionDTCPacket;
 import org.etools.j1939_84.bus.j1939.packets.LampStatus;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.RequestResult;
-import org.etools.j1939_84.modules.*;
+import org.etools.j1939_84.modules.BannerModule;
+import org.etools.j1939_84.modules.DTCModule;
+import org.etools.j1939_84.modules.DateTimeModule;
+import org.etools.j1939_84.modules.EngineSpeedModule;
+import org.etools.j1939_84.modules.VehicleInformationModule;
 
 /**
  * @author Marianne Schaefer (marianne.m.schaefer@gmail.com)
@@ -38,7 +42,7 @@ public class Step17Controller extends StepController {
              new VehicleInformationModule(),
              new DTCModule(),
              dataRepository,
-                DateTimeModule.getInstance());
+             DateTimeModule.getInstance());
     }
 
     Step17Controller(Executor executor,
@@ -65,54 +69,42 @@ public class Step17Controller extends StepController {
 
         dtcModule.setJ1939(getJ1939());
 
-        // 6.1.17.1 Actions:
-        // a. Global DM6 (send Request (PGN 59904) for PGN 65227 (SPNs
-        // 1213-1215, 3038, 1706)).
+        // 6.1.17.1.a. Global DM6 (send Request (PGN 59904) for PGN 65227 (SPNs 1213-1215, 3038, 1706)).
         RequestResult<DM6PendingEmissionDTCPacket> globalResponse = dtcModule.requestDM6(getListener());
 
-        globalResponse.getPackets().forEach(packet -> {
-            // 6.1.17.2 Fail criteria:
-            // a. Fail if any ECU reports pending DTCs
-            if (!packet.getDtcs().isEmpty()) {
-                addFailure("6.1.17.2.a - Fail if any ECU reports pending DTCs");
+        List<DM6PendingEmissionDTCPacket> globalPackets = globalResponse.getPackets();
+        // 6.1.17.2.c. Fail if no OBD ECU provides DM6.
+        if (globalPackets.isEmpty()) {
+            addFailure("6.1.17.2.c - No OBD ECU provided DM6");
+        } else {
+            for (DM6PendingEmissionDTCPacket packet : globalPackets) {
+                // 6.1.17.2.a. Fail if any ECU reports pending DTCs
+                if (!packet.getDtcs().isEmpty()) {
+                    addFailure("6.1.17.2.a - An ECU reported pending DTCs");
+                    break;
+                }
             }
-            // b. Fail if any ECU does not report MIL off.
-            if (packet.getMalfunctionIndicatorLampStatus() != LampStatus.OFF) {
-                addFailure("6.1.17.2.b - Fail if any ECU does not report MIL off");
+            for (DM6PendingEmissionDTCPacket packet : globalPackets) {
+                // 6.1.17.2.b. Fail if any ECU does not report MIL off.
+                if (packet.getMalfunctionIndicatorLampStatus() != LampStatus.OFF) {
+                    addFailure("6.1.17.2.b - An ECU did not report MIL off");
+                    break;
+                }
             }
-        });
-        // c. Fail if no OBD ECU provides DM6.
-        if (globalResponse.getPackets().isEmpty()) {
-            addFailure("6.1.17.2.c - Fail if no OBD ECU provides DM6");
+        }
 
-        }
-        // 6.1.17.3 Actions2:
-        // a. DS DM6 to each OBD ECU.
-        List<DM6PendingEmissionDTCPacket> destinationSpecificPackets = new ArrayList<>();
-        dataRepository.getObdModuleAddresses().forEach(address -> {
-            destinationSpecificPackets.addAll(dtcModule.requestDM6(getListener(), address).getPackets());
-        });
-        if (destinationSpecificPackets.isEmpty()) {
-            addWarning("6.1.17.3.a Destination Specific DM6 requests to OBD modules did not return any responses");
-        }
-        // 6.1.17.4 Fail criteria2:
-        // a. Fail if any difference compared to data received during global
-        // request.
-        List<DM6PendingEmissionDTCPacket> differentPackets = globalResponse.getPackets().stream()
-                .filter(packet -> {
-                    return !destinationSpecificPackets.contains(packet);
-                }).collect(Collectors.toList());
-        if (!differentPackets.isEmpty()) {
-            addFailure("6.1.17.4.a Fail if any difference compared to data received during global request");
-        }
-        // b. Fail if NACK not received from OBD ECUs that did not respond to
-        // global query.
-        List<DM6PendingEmissionDTCPacket> nacksRemovedPackets = differentPackets.stream().filter(packet -> {
-            return globalResponse.getAcks().stream()
-                    .anyMatch(ack -> ack.getSourceAddress() != packet.getSourceAddress());
-        }).collect(Collectors.toList());
-        if (!nacksRemovedPackets.isEmpty()) {
-            addFailure("6.1.17.4.b Fail if NACK not received from OBD ECUs that did not respond to global query");
-        }
+        // 6.1.17.3.a. DS DM6 to each OBD ECU.
+        List<Integer> obdModuleAddresses = dataRepository.getObdModuleAddresses();
+        List<RequestResult<DM6PendingEmissionDTCPacket>> dsResults = obdModuleAddresses.stream()
+                .map(address -> dtcModule.requestDM6(getListener(), address))
+                .collect(Collectors.toList());
+
+        // 6.1.17.4.a. Fail if any difference compared to data received during global request.
+        List<DM6PendingEmissionDTCPacket> dsPackets = filterRequestResultPackets(dsResults);
+        compareRequestPackets(globalPackets, dsPackets, "6.1.17.4.a");
+
+        // 6.1.17.4.b Fail if NACK not received from OBD ECUs that did not respond to global query
+        List<AcknowledgmentPacket> dsAcks = filterRequestResultAcks(dsResults);
+        checkForNACKs(globalPackets, dsAcks, obdModuleAddresses, "6.1.17.4.b");
     }
 }

--- a/src/org/etools/j1939_84/controllers/part1/Step18Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step18Controller.java
@@ -3,19 +3,21 @@
  */
 package org.etools.j1939_84.controllers.part1;
 
-import static org.etools.j1939_84.bus.j1939.Lookup.getAddressName;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
+import org.etools.j1939_84.bus.j1939.BusResult;
 import org.etools.j1939_84.bus.j1939.packets.DM12MILOnEmissionDTCPacket;
 import org.etools.j1939_84.bus.j1939.packets.LampStatus;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.RequestResult;
-import org.etools.j1939_84.modules.*;
+import org.etools.j1939_84.modules.BannerModule;
+import org.etools.j1939_84.modules.DTCModule;
+import org.etools.j1939_84.modules.DateTimeModule;
+import org.etools.j1939_84.modules.EngineSpeedModule;
+import org.etools.j1939_84.modules.VehicleInformationModule;
 
 /**
  * @author Marianne Schaefer (marianne.m.schaefer@gmail.com)
@@ -69,52 +71,40 @@ public class Step18Controller extends StepController {
         // 6.1.18.1.a. Global DM12 for PGN 65236
         RequestResult<DM12MILOnEmissionDTCPacket> globalResponse = dtcModule.requestDM12(getListener(), true);
 
-        globalResponse.getPackets().forEach(packet -> {
-            // 6.1.18.2.a. Fail if any ECU reports active DTCs.
-            if (!packet.getDtcs().isEmpty()) {
-                addFailure("6.1.18.2.a - An ECU reported active DTCs");
-            }
-            // 6.1.18.2.b. Fail if any ECU does not report MIL off.
-            if (packet.getMalfunctionIndicatorLampStatus() != LampStatus.OFF) {
-                addFailure("6.1.18.2.b - An ECU did not report MIL off");
-            }
-        });
-
         // 6.1.18.2.c. Fail if no OBD ECU provides DM12.
-        if (globalResponse.getPackets().isEmpty()) {
+        List<DM12MILOnEmissionDTCPacket> globalPackets = globalResponse.getPackets();
+        if (globalPackets.isEmpty()) {
             addFailure("6.1.18.2.c - No OBD ECU provided DM12");
+        } else {
+            for (DM12MILOnEmissionDTCPacket packet : globalPackets) {
+                // 6.1.18.2.a. Fail if any ECU reports active DTCs.
+                if (!packet.getDtcs().isEmpty()) {
+                    addFailure("6.1.18.2.a - An ECU reported active DTCs");
+                    break;
+                }
+            }
+
+            for (DM12MILOnEmissionDTCPacket packet : globalPackets) {
+                // 6.1.18.2.b. Fail if any ECU does not report MIL off.
+                if (packet.getMalfunctionIndicatorLampStatus() != LampStatus.OFF) {
+                    addFailure("6.1.18.2.b - An ECU did not report MIL off");
+                    break;
+                }
+            }
         }
+
+        List<Integer> obdModuleAddresses = dataRepository.getObdModuleAddresses();
 
         // 6.1.18.3.a. DS DM12 to all OBD ECUs.
-        List<DM12MILOnEmissionDTCPacket> destinationSpecificPackets = new ArrayList<>();
-        dataRepository.getObdModuleAddresses().forEach(address -> dtcModule.requestDM12(getListener(), true, address)
-                .getPacket()
-                .ifPresentOrElse((packet) -> {
-                    // No requirements around the destination specific acks so, the acks are not needed
-                    packet.left.ifPresent(destinationSpecificPackets::add);
-                }, () -> addWarning("6.1.18.3 OBD module " + getAddressName(address)
-                        + " did not return a response to a destination specific request")));
-        if (destinationSpecificPackets.isEmpty()) {
-            addWarning("6.1.18.3.a Destination Specific DM12 requests to OBD modules did not return any responses");
-        }
+        List<BusResult<DM12MILOnEmissionDTCPacket>> dsResults = obdModuleAddresses
+                .stream().map(address -> dtcModule.requestDM12(getListener(), true, address))
+                .collect(Collectors.toList());
 
         // 6.1.18.4.a. Fail if any difference compared to data received during global request.
-        List<DM12MILOnEmissionDTCPacket> differentPackets = globalResponse
-                .getPackets()
-                .stream()
-                .filter(packet -> !destinationSpecificPackets.contains(packet))
-                .collect(Collectors.toList());
-        if (!differentPackets.isEmpty()) {
-            addFailure("6.1.18.4.a Difference compared to data received during global request");
-        }
+        compareRequestPackets(globalPackets, filterPackets(dsResults), "6.1.18.4.a");
 
         // 6.1.18.4.b. Fail if NACK not received from OBD ECUs that did not respond to global query.
-        List<DM12MILOnEmissionDTCPacket> nacksRemovedPackets = differentPackets.stream()
-                .filter(packet -> globalResponse.getAcks().stream()
-                        .anyMatch(ack -> ack.getSourceAddress() != packet.getSourceAddress()))
-                .collect(Collectors.toList());
-        if (!nacksRemovedPackets.isEmpty()) {
-            addFailure("6.1.18.4.b NACK not received from OBD ECUs that did not respond to global query");
-        }
+        checkForNACKs(globalPackets, filterAcks(dsResults), obdModuleAddresses, "6.1.18.4.b");
+
     }
 }

--- a/src/org/etools/j1939_84/controllers/part1/Step19Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step19Controller.java
@@ -1,29 +1,30 @@
-/**
- * Copyright 2020 Equipment & Tool Institute
+/*
+ * Copyright 2021 Equipment & Tool Institute
  */
 package org.etools.j1939_84.controllers.part1;
 
-import static org.etools.j1939_84.bus.j1939.Lookup.getAddressName;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
+import org.etools.j1939_84.bus.j1939.BusResult;
+import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM23PreviouslyMILOnEmissionDTCPacket;
 import org.etools.j1939_84.bus.j1939.packets.LampStatus;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.RequestResult;
-import org.etools.j1939_84.modules.*;
+import org.etools.j1939_84.modules.BannerModule;
+import org.etools.j1939_84.modules.DTCModule;
+import org.etools.j1939_84.modules.DateTimeModule;
+import org.etools.j1939_84.modules.EngineSpeedModule;
+import org.etools.j1939_84.modules.VehicleInformationModule;
 
 /**
  * @author Marianne Schaefer (marianne.m.schaefer@gmail.com)
  * <p>
- * The controller for 6.1.19 DM23: Emission Related Previously Active
- * DTCs
+ * The controller for 6.1.19 DM23: Emission Related Previously Active DTCs
  */
-
 public class Step19Controller extends StepController {
 
     private static final int PART_NUMBER = 1;
@@ -41,7 +42,7 @@ public class Step19Controller extends StepController {
              new VehicleInformationModule(),
              new DTCModule(),
              dataRepository,
-                DateTimeModule.getInstance());
+             DateTimeModule.getInstance());
     }
 
     Step19Controller(Executor executor,
@@ -68,66 +69,41 @@ public class Step19Controller extends StepController {
 
         dtcModule.setJ1939(getJ1939());
 
-        // 6.1.19.1 Actions:
-        // a. Global DM23 (send Request (PGN 59904) for PGN 64949 (SPNs
-        // 1213-1215, 3038, 1706)).
+        // 6.1.19.1.a. Global DM23 (send Request (PGN 59904) for PGN 64949 (SPNs 1213-1215, 3038, 1706)).
         RequestResult<DM23PreviouslyMILOnEmissionDTCPacket> globalResponse = dtcModule.requestDM23(getListener(), true);
-
-        globalResponse.getPackets().forEach(packet -> {
-            // 6.1.19.2 Fail criteria:
-            // a. Fail if any ECU reports previously active DTCs.
-            if (!packet.getDtcs().isEmpty()) {
-                addFailure("6.1.19.2.a - Fail if any ECU reports active DTCs");
+        // 6.1.19.1.c. Fail if no OBD ECU provides DM23.
+        List<DM23PreviouslyMILOnEmissionDTCPacket> globalPackets = globalResponse.getPackets();
+        if (globalPackets.isEmpty()) {
+            addFailure("6.1.19.2.c - No OBD ECU provided DM23");
+        } else {
+            for (DM23PreviouslyMILOnEmissionDTCPacket packet : globalPackets) {
+                // 6.1.19.2.a. Fail if any ECU reports previously active DTCs.
+                if (!packet.getDtcs().isEmpty()) {
+                    addFailure("6.1.19.2.a - An ECU reported active DTCs");
+                    break;
+                }
             }
-            // b. Fail if any ECU does not report MIL off. See section A.8 for
-            // allowed values.
-            if (packet.getMalfunctionIndicatorLampStatus() != LampStatus.OFF) {
-                addFailure("6.1.19.2.b - Fail if any ECU does not report MIL off");
+            for (DM23PreviouslyMILOnEmissionDTCPacket packet : globalPackets) {
+                // 6.1.19.2.b. Fail if any ECU does not report MIL off.
+                if (packet.getMalfunctionIndicatorLampStatus() != LampStatus.OFF) {
+                    addFailure("6.1.19.2.b - An ECU did not report MIL off");
+                    break;
+                }
             }
-        });
-        // c. Fail if no OBD ECU provides DM23.
-        if (globalResponse.getPackets().isEmpty()) {
-            addFailure("6.1.19.2.c - Fail if no OBD ECU provides DM23");
+        }
 
-        }
-        // 6.1.19.3 Actions2:
-        // a. DS DM23 to each OBD ECU.
-        List<DM23PreviouslyMILOnEmissionDTCPacket> destinationSpecificPackets = new ArrayList<>();
-        dataRepository.getObdModuleAddresses().forEach(address -> {
-            dtcModule.requestDM23(getListener(), true, address)
-                    .getPacket()
-                    .ifPresentOrElse((packet) -> {
-                        // No requirements around the destination specific acks
-                        // so, the acks are not needed
-                        if (packet.left.isPresent()) {
-                            destinationSpecificPackets.add(packet.left.get());
-                        }
-                    }, () -> {
-                        addWarning("6.1.19.3 OBD module " + getAddressName(address)
-                                           + " did not return a response to a destination specific request");
-                    });
-        });
-        if (destinationSpecificPackets.isEmpty()) {
-            addWarning("6.1.19.3.a Destination Specific DM23 requests to OBD modules did not return any responses");
-        }
-        // 6.1.19.4 Fail criteria2:
-        // a. Fail if any difference compared to data received during global
-        // request.
-        List<DM23PreviouslyMILOnEmissionDTCPacket> differentPackets = globalResponse.getPackets().stream()
-                .filter(packet -> {
-                    return !destinationSpecificPackets.contains(packet);
-                }).collect(Collectors.toList());
-        if (!differentPackets.isEmpty()) {
-            addFailure("6.1.19.4.a Fail if any difference compared to data received during global request");
-        }
-        // b. Fail if NACK not received from OBD ECUs that did not respond to
-        // global query.
-        List<DM23PreviouslyMILOnEmissionDTCPacket> nacksRemovedPackets = differentPackets.stream().filter(packet -> {
-            return globalResponse.getAcks().stream()
-                    .anyMatch(ack -> ack.getSourceAddress() != packet.getSourceAddress());
-        }).collect(Collectors.toList());
-        if (!nacksRemovedPackets.isEmpty()) {
-            addFailure("6.1.19.4.b Fail if NACK not received from OBD ECUs that did not respond to global query");
-        }
+        // 6.1.19.3.a. DS DM23 to each OBD ECU.
+        List<Integer> obdModuleAddresses = dataRepository.getObdModuleAddresses();
+        List<BusResult<DM23PreviouslyMILOnEmissionDTCPacket>> dsResults = obdModuleAddresses.stream()
+                .map(address -> dtcModule.requestDM23(getListener(), true, address))
+                .collect(Collectors.toList());
+
+        // 6.1.19.4.a. Fail if any difference compared to data received during global request.
+        List<DM23PreviouslyMILOnEmissionDTCPacket> dsPackets = filterPackets(dsResults);
+        compareRequestPackets(globalPackets, dsPackets, "6.1.19.4.a");
+
+        // 6.1.19.4.b Fail if NACK not received from OBD ECUs that did not respond to global query
+        List<AcknowledgmentPacket> dsAcks = filterAcks(dsResults);
+        checkForNACKs(globalPackets, dsAcks, obdModuleAddresses, "6.1.19.4.b");
     }
 }

--- a/src/org/etools/j1939_84/controllers/part1/Step21Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step21Controller.java
@@ -1,21 +1,24 @@
-/**
- * Copyright 2020 Equipment & Tool Institute
+/*
+ * Copyright 2021 Equipment & Tool Institute
  */
 package org.etools.j1939_84.controllers.part1;
 
-import static org.etools.j1939_84.bus.j1939.Lookup.getAddressName;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
+import org.etools.j1939_84.bus.j1939.BusResult;
+import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM27AllPendingDTCsPacket;
 import org.etools.j1939_84.bus.j1939.packets.LampStatus;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.RequestResult;
-import org.etools.j1939_84.modules.*;
+import org.etools.j1939_84.modules.BannerModule;
+import org.etools.j1939_84.modules.DTCModule;
+import org.etools.j1939_84.modules.DateTimeModule;
+import org.etools.j1939_84.modules.EngineSpeedModule;
+import org.etools.j1939_84.modules.VehicleInformationModule;
 
 /**
  * @author Marianne Schaefer (marianne.m.schaefer@gmail.com)
@@ -67,61 +70,38 @@ public class Step21Controller extends StepController {
 
         dtcModule.setJ1939(getJ1939());
 
-        // 6.1.21.1 Actions:
-        // a. Global DM27 (send Request (PGN 59904) for PGN 64898 (SPNs
-        // 1213-1215, 3038, 1706)).
+        // 6.1.21.1.a. Global DM27 (send Request (PGN 59904) for PGN 64898 (SPNs 1213-1215, 3038, 1706)).
         RequestResult<DM27AllPendingDTCsPacket> globalResponse = dtcModule.requestDM27(getListener(), true);
 
         List<Integer> obdModuleAddresses = dataRepository.getObdModuleAddresses();
-        globalResponse.getPackets().forEach(packet -> {
+        List<DM27AllPendingDTCsPacket> globalPackets = globalResponse.getPackets();
 
-            // 6.1.21.2 Fail criteria: (if supported)
-            // a. Fail if any OBD ECU reports an all pending DTC.
+        for (DM27AllPendingDTCsPacket packet : globalPackets) {
+            // 6.1.21.2.a. Fail if any OBD ECU reports an all pending DTC.
             if (!packet.getDtcs().isEmpty() && obdModuleAddresses.contains(packet.getSourceAddress())) {
-                addFailure("6.1.21.2.a - Fail if any OBD ECU reports an all pending DTC");
+                addFailure("6.1.21.2.a - An OBD ECU reported an all pending DTC");
+                break;
             }
-            // b. Fail if any ECU does not report MIL off
+        }
+        for (DM27AllPendingDTCsPacket packet : globalPackets) {
+            // 6.1.21.2.b. Fail if any ECU does not report MIL off
             if (packet.getMalfunctionIndicatorLampStatus() != LampStatus.OFF) {
-                addFailure("6.1.21.2.b - Fail if any ECU does not report MIL off");
+                addFailure("6.1.21.2.b - An ECU did not report MIL off");
+                break;
             }
-        });
-
-        // 6.1.21.3 Actions2:
-        // a. DS DM27 to each OBD ECU.
-        List<DM27AllPendingDTCsPacket> destinationSpecificPackets = new ArrayList<>();
-        obdModuleAddresses.forEach(address -> {
-            dtcModule.requestDM27(getListener(), true, address)
-                    .getPacket()
-                    .ifPresentOrElse((packet) -> {
-                        // No requirements around the destination specific acks
-                        // so, the acks are not needed
-                        if (packet.left.isPresent()) {
-                            destinationSpecificPackets.add(packet.left.get());
-                        }
-                    }, () -> {
-                        addWarning("6.1.21.3 OBD module " + getAddressName(address)
-                                           + " did not return a response to a destination specific request");
-                    });
-        });
-
-        // 6.1.21.4 Fail criteria2:
-        // a. Fail if any difference compared to data received during global
-        // request.
-        List<DM27AllPendingDTCsPacket> differentPackets = globalResponse.getPackets().stream()
-                .filter(packet -> {
-                    return !destinationSpecificPackets.contains(packet);
-                }).collect(Collectors.toList());
-        if (!differentPackets.isEmpty()) {
-            addFailure("6.1.21.4.a Fail if any difference compared to data received during global request");
         }
-        // b. Fail if NACK not received from OBD ECUs that did not respond to
-        // global query.
-        List<DM27AllPendingDTCsPacket> nacksRemovedPackets = differentPackets.stream().filter(packet -> {
-            return globalResponse.getAcks().stream()
-                    .anyMatch(ack -> ack.getSourceAddress() != packet.getSourceAddress());
-        }).collect(Collectors.toList());
-        if (!nacksRemovedPackets.isEmpty()) {
-            addFailure("6.1.21.4.b Fail if NACK not received from OBD ECUs that did not respond to global query");
-        }
+
+        // 6.1.21.3.a. DS DM28 to each OBD ECU.
+        List<BusResult<DM27AllPendingDTCsPacket>> dsResults = obdModuleAddresses.stream()
+                .map(address -> dtcModule.requestDM27(getListener(), true, address))
+                .collect(Collectors.toList());
+
+        // 6.1.20.4.a. Fail if any difference compared to data received during global request.
+        List<DM27AllPendingDTCsPacket> dsPackets = filterPackets(dsResults);
+        compareRequestPackets(globalPackets, dsPackets, "6.1.21.4.a");
+
+        // 6.1.20.4.b Fail if NACK not received from OBD ECUs that did not respond to global query
+        List<AcknowledgmentPacket> dsAcks = filterAcks(dsResults);
+        checkForNACKs(globalPackets, dsAcks, obdModuleAddresses, "6.1.21.4.b");
     }
 }

--- a/src/org/etools/j1939_84/controllers/part1/Step22Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step22Controller.java
@@ -1,25 +1,24 @@
-/**
- * Copyright 2020 Equipment & Tool Institute
+/*
+ * Copyright 2021 Equipment & Tool Institute
  */
 package org.etools.j1939_84.controllers.part1;
 
-import static org.etools.j1939_84.bus.j1939.Lookup.getAddressName;
-
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
-import org.etools.j1939_84.bus.Packet;
-import org.etools.j1939_84.bus.j1939.Lookup;
+import org.etools.j1939_84.bus.j1939.BusResult;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
-import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response;
 import org.etools.j1939_84.bus.j1939.packets.DM29DtcCounts;
+import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.RequestResult;
-import org.etools.j1939_84.modules.*;
+import org.etools.j1939_84.modules.BannerModule;
+import org.etools.j1939_84.modules.DTCModule;
+import org.etools.j1939_84.modules.DateTimeModule;
+import org.etools.j1939_84.modules.EngineSpeedModule;
+import org.etools.j1939_84.modules.VehicleInformationModule;
 
 /**
  * @author Marianne Schaefer (marianne.m.schaefer@gmail.com)
@@ -44,7 +43,7 @@ public class Step22Controller extends StepController {
              new VehicleInformationModule(),
              new DTCModule(),
              dataRepository,
-                DateTimeModule.getInstance());
+             DateTimeModule.getInstance());
     }
 
     Step22Controller(Executor executor,
@@ -73,116 +72,71 @@ public class Step22Controller extends StepController {
 
         List<Integer> obdModuleAddresses = dataRepository.getObdModuleAddresses();
 
-        // 6.1.22.1 Actions:
-        // a. Global DM29 (send Request (PGN 59904) for PGN 40448 (SPNs
-        // 4104-4108)).
+        // 6.1.22.1.a. Global DM29 (send Request (PGN 59904) for PGN 40448 (SPNs 4104-4108)).
         RequestResult<DM29DtcCounts> globalResponse = dtcModule.requestDM29(getListener());
 
         List<DM29DtcCounts> globalPackets = globalResponse.getPackets();
-        globalPackets.forEach(dm29 -> {
-
-            // 6.1.22.2 Fail criteria:
-            // a. For ECUs that support DM27, fail if any ECU does not report
+        for (DM29DtcCounts dm29 : globalPackets) {
+            // 6.1.22.2.a. For ECUs that support DM27, fail if any ECU does not report
             // pending/all pending/MIL on/previous MIL on/permanent = 0/0/0/0/0
             if (dm29.isDM27Supported() && (dm29.getEmissionRelatedPendingDTCCount() != 0
                     || dm29.getEmissionRelatedMILOnDTCCount() != 0
                     || dm29.getEmissionRelatedPreviouslyMILOnDTCCount() != 0
                     || dm29.getEmissionRelatedPermanentDTCCount() != 0)) {
-                addFailure("6.1.22.2.a - For ECUs that support DM27, fail if any ECU does "
-                                   + "not report pending/all pending/MIL on/previous MIL on/permanent = 0/0/0/0/0");
+                addFailure(
+                        "6.1.22.2.a - An ECU did not report pending/all pending/MIL on/previous MIL on/permanent = 0/0/0/0/0");
+                break;
             }
+        }
 
-            // b. For ECUs that do not support DM27, fail if any ECU does not
-            // report pending/all pending/MIL on/previous MIL on/permanent =
-            // 0/0xFF/0/0/0.
+        for (DM29DtcCounts dm29 : globalPackets) {
+            // 6.1.22.2.b. For ECUs that do not support DM27, fail if any ECU does not
+            // report pending/all pending/MIL on/previous MIL on/permanent =0/0xFF/0/0/0.
             if (!dm29.isDM27Supported() &&
                     (dm29.getEmissionRelatedPendingDTCCount() != 0x00
-                    || dm29.getEmissionRelatedMILOnDTCCount() != 0x00
-                    || dm29.getEmissionRelatedPreviouslyMILOnDTCCount() != 0x00
-                    || dm29.getEmissionRelatedPermanentDTCCount() != 0x00)) {
-                addFailure("6.1.22.2.b - For ECUs that do not support DM27, fail if any ECU does "
-                                   + "not report pending/all pending/MIL on/previous MIL on/permanent = 0/0xFF/0/0/0");
+                            || dm29.getEmissionRelatedMILOnDTCCount() != 0x00
+                            || dm29.getEmissionRelatedPreviouslyMILOnDTCCount() != 0x00
+                            || dm29.getEmissionRelatedPermanentDTCCount() != 0x00)) {
+                addFailure(
+                        "6.1.22.2.b - An ECU did not report pending/all pending/MIL on/previous MIL on/permanent = 0/0xFF/0/0/0");
+                break;
             }
+        }
 
-            // c. For non-OBD ECUs, fail if any ECU reports pending, MIL-on,
-            // previously MIL-on or permanent DTC count greater than 0
+        for (DM29DtcCounts dm29 : globalPackets) {
+            // 6.1.22.2.c. For non-OBD ECUs, fail if any ECU reports pending, MIL-on, previously MIL-on or permanent DTC count greater than 0
             if (!obdModuleAddresses.contains(dm29.getSourceAddress())
                     && (dm29.getEmissionRelatedPendingDTCCount() > 0
-                    ||dm29.getEmissionRelatedMILOnDTCCount() > 0
+                    || dm29.getEmissionRelatedMILOnDTCCount() > 0
                     || dm29.getEmissionRelatedPreviouslyMILOnDTCCount() > 0
                     || dm29.getEmissionRelatedPermanentDTCCount() > 0)) {
-                addFailure("6.1.22.2.c - For non-OBD ECUs, fail if any ECU reports pending, MIL-on, "
-                                   + "previously MIL-on or permanent DTC count greater than 0");
-
+                addFailure("6.1.22.2.c - A non-OBD ECU reported pending, MIL-on, previously MIL-on or permanent DTC count greater than 0");
+                break;
             }
-        });
+        }
 
-        // d. Fail if no OBD ECU provides DM29.
-        Optional<Integer> obdAddresses = globalPackets
+        // 6.1.22.2.d. Fail if no OBD ECU provides DM29.
+        boolean noObdResponses = globalPackets
                 .stream()
-                .map(p -> p.getSourceAddress())
-                .filter(a -> obdModuleAddresses.contains(a))
-                .findAny();
-        if (!obdAddresses.isPresent()) {
-            addFailure("6.1.22.2.c - Fail if no OBD ECU provides DM29");
+                .map(ParsedPacket::getSourceAddress)
+                .filter(obdModuleAddresses::contains)
+                .findAny()
+                .isEmpty();
+        if (noObdResponses) {
+            addFailure("6.1.22.2.d - No OBD ECU provided DM29");
         }
 
-        // 6.1.22.3 Actions:
-        // a. DS DM29 to each OBD ECU.
-        List<DM29DtcCounts> destinationSpecificPackets = new ArrayList<>();
-        List<AcknowledgmentPacket> destinationSpecificAcks = new ArrayList<>();
-        obdModuleAddresses.forEach(address -> {
-            dtcModule.requestDM29(getListener(), address)
-                    .getPacket()
-                    .ifPresentOrElse((packet) -> {
-                        // No requirements around the destination specific acks
-                        // so, the acks are not needed
-                        if (packet.left.isPresent()) {
-                            destinationSpecificPackets.add(packet.left.get());
-                        }
-                        if (packet.right.isPresent()) {
-                            destinationSpecificAcks.add(packet.right.get());
-                        }
-                    }, () -> {
-                        addWarning("6.1.22.3 - OBD module " + getAddressName(address)
-                                           + " did not return a response to a destination specific request");
-                    });
-        });
-        if (destinationSpecificPackets.isEmpty()) {
-            addWarning(
-                    "6.1.22.3.a - Destination Specific DM29 requests to OBD modules did not return any responses");
-        }
-
-        // 6.1.22.4 Fail criteria:
-        // a. Fail if any difference compared to data received during global
-        // request.
-        List<DM29DtcCounts> differentPackets = globalPackets.stream()
-                .filter(packet -> {
-                    return !destinationSpecificPackets.contains(packet);
-                }).collect(Collectors.toList());
-        if (!differentPackets.isEmpty()) {
-            addFailure("6.1.22.4.a - Fail if any difference compared to data received during global request");
-        }
-
-        // b. Fail if NACK not received from OBD ECUs that did not respond to
-        // global query.
-        List<Integer> responseAddresses = globalPackets
-                .stream()
-                .map(p -> p.getSourceAddress())
+        // 6.1.22.3.a. DS DM29 to each OBD ECU.
+        List<BusResult<DM29DtcCounts>> dsResults = obdModuleAddresses.stream()
+                .map(address -> dtcModule.requestDM29(getListener(), address))
                 .collect(Collectors.toList());
 
-        obdModuleAddresses.removeAll(responseAddresses);
+        // 6.1.22.4.a. Fail if any difference compared to data received during global request.
+        List<DM29DtcCounts> dsPackets = filterPackets(dsResults);
+        compareRequestPackets(globalPackets, dsPackets, "6.1.22.4.a");
 
-        List<Integer> nackAddresses = destinationSpecificAcks.stream()
-                .map(p -> p)
-                .filter(ack -> ack.getResponse() == Response.NACK)
-                .map(ack -> ack.getSourceAddress())
-                .collect(Collectors.toList());
-        obdModuleAddresses.removeAll(nackAddresses);
-        obdModuleAddresses.forEach(address -> {
-            addFailure(
-                    "6.1.22.4.b - Fail if NACK not received from OBD ECUs that did not respond to global query - OBD module "
-                            + Lookup.getAddressName(address) + " did not return a response");
-        });
+        // 6.1.22.4.b Fail if NACK not received from OBD ECUs that did not respond to global query
+        List<AcknowledgmentPacket> dsAcks = filterAcks(dsResults);
+        checkForNACKs(globalPackets, dsAcks, obdModuleAddresses, "6.1.22.4.b");
     }
 }

--- a/src/org/etools/j1939_84/controllers/part1/Step24Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Step24Controller.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2020 Equipment & Tool Institute
+/*
+ * Copyright 2021 Equipment & Tool Institute
  */
 package org.etools.j1939_84.controllers.part1;
 
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import org.etools.j1939_84.bus.j1939.packets.DM25ExpandedFreezeFrame;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
+import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.*;
 
 /**
@@ -62,15 +63,14 @@ public class Step24Controller extends StepController {
 
         dtcModule.setJ1939(getJ1939());
 
-        // 6.1.24.1 Actions:
-        // a.. DS DM25 (send Request (PGN 59904) for PGN 64951 (SPNs 3300,
+        // 6.1.24.1.a. DS DM25 (send Request (PGN 59904) for PGN 64951 (SPNs 3300,
         // 1214-1215)) to each OBD ECU that responded to DS DM24 with supported
         // freeze frame SPNs.
 
         // First get the correct OBD Modules per requirements
         List<Integer> obdModuleAddresses = dataRepository.getObdModules().stream()
                 .filter(module -> !module.getFreezeFrameSpns().isEmpty())
-                .map(m -> m.getSourceAddress())
+                .map(OBDModuleInformation::getSourceAddress)
                 .collect(Collectors.toList());
 
         // Get the responses from each of the modules required
@@ -91,14 +91,11 @@ public class Step24Controller extends StepController {
                 })
                 .collect(Collectors.toList());
 
-        // 6.1.24.2 Fail criteria:
-        // a. Fail if any OBD ECU provides freeze frame data other than no
-        // freeze frame data stored [i.e., bytes 1-5= 0x00 and
-        // bytes 6-8 = 0xFF]
+        // 6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no
+        // freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]
         if (!dm25Packets.isEmpty()) {
             // Verify the no data & DTC didn't cause freeze frame
-            addFailure(
-                    "6.1.24.2.a. Fail if any OBD ECU provides freeze frame data other than no freeze frame data stored [i.e., bytes 1-5= 0x00 and bytes 6-8 = 0xFF]");
+            addFailure("6.1.24.2.a - An OBD ECU provided freeze frame data other than no freeze frame data stored");
         }
     }
 }


### PR DESCRIPTION
Centralize the check for Missing NACKs and differences between Global and DS Responses in the StepController.  Then fixed all the tests.