### PR TITLE
Fix #498 6.1.10 DM11 should not have retries

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part1/Part01Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Part01Step10ControllerTest.java
@@ -4,6 +4,7 @@
 package org.etools.j1939_84.controllers.part1;
 
 import static org.etools.j1939_84.J1939_84.NL;
+import static org.etools.j1939_84.model.Outcome.FAIL;
 import static org.etools.j1939_84.model.Outcome.WARN;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -12,18 +13,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
 import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response;
-import org.etools.j1939_84.bus.j1939.packets.DM11ClearActiveDTCsPacket;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.TestResultsListener;
-import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DTCModule;
 import org.etools.j1939_84.modules.DateTimeModule;
@@ -96,12 +93,12 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
     @After
     public void tearDown() throws Exception {
         verifyNoMoreInteractions(executor,
-                engineSpeedModule,
-                bannerModule,
-                vehicleInformationModule,
-                dtcModule,
-                mockListener,
-                dataRepository);
+                                 engineSpeedModule,
+                                 bannerModule,
+                                 vehicleInformationModule,
+                                 dtcModule,
+                                 mockListener,
+                                 dataRepository);
     }
 
     @Test
@@ -116,34 +113,32 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
         AcknowledgmentPacket nackPacket = mock(AcknowledgmentPacket.class);
         when(nackPacket.getResponse()).thenReturn(Response.NACK);
         when(nackPacket.getSourceAddress()).thenReturn(1);
-        List<AcknowledgmentPacket> acknowledgmentPackets = new ArrayList<>() {
-            {
-                add(ackPacket);
-                add(nackPacket);
-                add(ackPacket2);
-            }
-        };
+
+        List<AcknowledgmentPacket> acknowledgmentPackets = List.of(ackPacket, nackPacket, ackPacket2);
+
         when(dataRepository.isObdModule(0)).thenReturn(true);
         when(dataRepository.isObdModule(1)).thenReturn(true);
         when(dataRepository.isObdModule(2)).thenReturn(false);
 
-        when(dtcModule.requestDM11(any()))
-                .thenReturn(new RequestResult<>(false, Collections.emptyList(),
-                        acknowledgmentPackets));
+        when(dtcModule.requestDM11(any())).thenReturn(acknowledgmentPackets);
+
         runTest();
 
         verify(dtcModule).setJ1939(j1939);
         verify(dtcModule).requestDM11(any());
 
-        verify(mockListener).addOutcome(1, 10, WARN, "6.1.10.3.a - The request for DM11 was NACK'ed");
-        verify(mockListener).addOutcome(1, 10, WARN, "6.1.10.3.a - The request for DM11 was ACK'ed");
+        verify(mockListener).addOutcome(1, 10, FAIL, "6.1.10.3.a - The request for DM11 was NACK'ed by Engine #2 (1)");
+        verify(mockListener).addOutcome(1, 10, WARN, "6.1.10.3.a - The request for DM11 was ACK'ed by Engine #1 (0)");
 
         verify(dataRepository).isObdModule(0);
         verify(dataRepository).isObdModule(1);
         verify(dataRepository).isObdModule(2);
 
-        assertEquals("WARN: 6.1.10.3.a - The request for DM11 was NACK'ed" + NL + "WARN: 6.1.10.3.a - The request for DM11 was ACK'ed" + NL,
-                listener.getResults());
+        String expected = "";
+        expected += "FAIL: 6.1.10.3.a - The request for DM11 was NACK'ed by Engine #2 (1)" + NL;
+        expected += "WARN: 6.1.10.3.a - The request for DM11 was ACK'ed by Engine #1 (0)" + NL;
+        assertEquals(expected, listener.getResults());
+
         String expectedMessages = "";
         expectedMessages += "Waiting for 5 seconds" + NL;
         expectedMessages += "Waiting for 4 seconds" + NL;
@@ -178,11 +173,7 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
 
         when(dataRepository.isObdModule(0)).thenReturn(true);
 
-        DM11ClearActiveDTCsPacket dm11Packet = mock(DM11ClearActiveDTCsPacket.class);
-
-        when(dtcModule.requestDM11(any()))
-                .thenReturn(new RequestResult<>(false, Collections.singletonList(dm11Packet),
-                        Collections.singletonList(acknowledgmentPacket)));
+        when(dtcModule.requestDM11(any())).thenReturn(List.of(acknowledgmentPacket));
 
         runTest();
 

--- a/src/org/etools/j1939_84/bus/j1939/J1939.java
+++ b/src/org/etools/j1939_84/bus/j1939/J1939.java
@@ -516,6 +516,18 @@ public class J1939 {
         }
     }
 
+    public List<AcknowledgmentPacket> requestDm11(ResultsListener listener) {
+        listener.onResult(getDateTimeModule().getTime() + " " + "Global DM11 Request");
+
+        Packet requestPacket = createRequestPacket(DM11ClearActiveDTCsPacket.PGN, GLOBAL_ADDR);
+        final int pgn = getPgn(DM11ClearActiveDTCsPacket.class);
+        var responses = requestGlobalOnce(pgn, requestPacket, listener, true);
+
+        return responses.stream()
+                .flatMap(e -> e.right.stream())
+                .collect(Collectors.toList());
+    }
+
     /**
      * Request a packet from a specific address. As long as the module responds
      * "busy", retry for up to 1.2s. Fail after 3 non-responses.

--- a/src/org/etools/j1939_84/controllers/StepController.java
+++ b/src/org/etools/j1939_84/controllers/StepController.java
@@ -139,6 +139,20 @@ public abstract class StepController extends Controller {
                 .forEach(this::addWarning);
     }
 
+    protected void pause(String message, long secondsToSleep) {
+        long stopTime = getDateTimeModule().getTimeAsLong() + (secondsToSleep * 1000L);
+        long secondsToGo;
+        while (true) {
+            secondsToGo = (stopTime - getDateTimeModule().getTimeAsLong()) / 1000;
+            if (secondsToGo > 0) {
+                getListener().onProgress(String.format(message, secondsToGo));
+                getDateTimeModule().pauseFor(1000);
+            } else {
+                break;
+            }
+        }
+    }
+
     protected static <T extends GenericPacket> List<T> filterRequestResultPackets(List<RequestResult<T>> results) {
         return results.stream().flatMap(r -> r.getPackets().stream()).collect(Collectors.toList());
     }

--- a/src/org/etools/j1939_84/modules/DTCModule.java
+++ b/src/org/etools/j1939_84/modules/DTCModule.java
@@ -15,8 +15,8 @@ import java.util.stream.Collectors;
 import org.etools.j1939_84.bus.Packet;
 import org.etools.j1939_84.bus.j1939.BusResult;
 import org.etools.j1939_84.bus.j1939.Lookup;
+import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response;
-import org.etools.j1939_84.bus.j1939.packets.DM11ClearActiveDTCsPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM12MILOnEmissionDTCPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM1ActiveDTCsPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM21DiagnosticReadinessPacket;
@@ -86,20 +86,18 @@ public class DTCModule extends FunctionalModule {
      * @param listener
      *         the {@link ResultsListener} that will be given the report
      */
-    public RequestResult<DM11ClearActiveDTCsPacket> requestDM11(ResultsListener listener) {
+    public List<AcknowledgmentPacket> requestDM11(ResultsListener listener) {
         listener.onResult(getTime() + " Clearing Diagnostic Trouble Codes");
-        Packet requestPacket = getJ1939().createRequestPacket(DM11ClearActiveDTCsPacket.PGN, GLOBAL_ADDR);
 
-        var results = getJ1939()
-                .requestResult("Global DM11 Request", listener, true, DM11ClearActiveDTCsPacket.class, requestPacket);
+        List<AcknowledgmentPacket> responses = getJ1939().requestDm11(listener);
 
-        if (!results.getAcks().isEmpty() && results.getAcks().stream().allMatch(t -> t.getResponse() == Response.ACK)) {
+        if (!responses.isEmpty() && responses.stream().allMatch(t -> t.getResponse() == Response.ACK)) {
             listener.onResult(DTCS_CLEARED);
         } else {
             listener.onResult("ERROR: Clearing Diagnostic Trouble Codes failed.");
         }
 
-        return results;
+        return responses;
     }
 
     /**


### PR DESCRIPTION
Added `requestDM11()` method to `J1939` class which will request DM11 and return AckPackets. This allows the method to then call `globalRequestOnce()` which will not retry the request.