### PR TITLE
Fix #510 Part 1 Step 26 - Exclude checking for particular SPNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # j1939-84
-This tool in an implementation of the SAE J1939-84 specifications for etools.org
+This tool is an implementation of the SAE J1939-84 specifications for etools.org
 
 This tool is used to verify that vehicles and/or components are capable of communicating a required set of information,
 in accordance with the diagnostic messages specified in SAE J1939-73, to fulfill the off-board diagnostic tool interface 
@@ -7,14 +7,6 @@ requirements contained in various government regulations, including the HD OBD r
 California’s Air Resources Board (ARB).
 
 ##Known Issues
-* Part 1 Step 26 Requests SPs that map to multiple PGs
-    * Some Suspect Parameters (SP) map to multiple Parameter Groups (PG).  Thus the tool request or listens for the 
-      various PG, when the OBD Module intends only to support a subset of those PGs.  This results in failures.
-      Issues include:
-        * https://github.com/battjt/j1939-84/issues/511
-        * https://github.com/battjt/j1939-84/issues/510
-        * https://github.com/battjt/j1939-84/issues/509
-
 
 * Part 1 Step 26 Doesn't handle J1939-21 DA Model Year changes
     * Some Parameter Groups change the broadcast rates or methods between model years of vehicles.  How should this be handled?

--- a/src-test/org/etools/j1939_84/bus/j1939/J1939Test.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/J1939Test.java
@@ -438,9 +438,6 @@ public class J1939Test {
      */
     @Test
     public void testRequestDM7Timesout() throws Exception {
-        when(bus.read(220, MILLISECONDS)).thenReturn(Stream.of()).thenReturn(Stream.of())
-                .thenReturn(Stream.of());
-
         Object packet = instance.requestDM7(1024, 0, NOOP).getPacket().orElse(null);
         assertNull(packet);
 

--- a/src-test/org/etools/j1939_84/controllers/TableA1ValidatorTest.java
+++ b/src-test/org/etools/j1939_84/controllers/TableA1ValidatorTest.java
@@ -236,7 +236,7 @@ public class TableA1ValidatorTest {
         supportedSpns.add(mockSupportedSpn(158));// PASS
         supportedSpns.add(mockSupportedSpn(96));// INFO
         supportedSpns.add(mockSupportedSpn(92));// Provided
-        when(obdModuleInformation.getDataStreamSpns()).thenReturn(supportedSpns);
+        when(obdModuleInformation.getFilteredDataStreamSPNs()).thenReturn(supportedSpns);
 
         dataRepository.putObdModule(obdModuleInformation);
 

--- a/src-test/org/etools/j1939_84/controllers/part1/BroadcastValidatorTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/BroadcastValidatorTest.java
@@ -329,12 +329,12 @@ public class BroadcastValidatorTest {
 
         OBDModuleInformation module1 = mock(OBDModuleInformation.class);
         List<SupportedSPN> supportedSPNs1 = supportedSPNs(111, 222);
-        when(module1.getDataStreamSpns()).thenReturn(supportedSPNs1);
+        when(module1.getFilteredDataStreamSPNs()).thenReturn(supportedSPNs1);
         modules.add(module1);
 
         OBDModuleInformation module2 = mock(OBDModuleInformation.class);
         List<SupportedSPN> supportedSPNs2 = supportedSPNs(333, 444);
-        when(module2.getDataStreamSpns()).thenReturn(supportedSPNs2);
+        when(module2.getFilteredDataStreamSPNs()).thenReturn(supportedSPNs2);
         modules.add(module2);
 
         when(j1939DaRepository.getPgnForSpn(111)).thenReturn(Set.of(11111));

--- a/src-test/org/etools/j1939_84/controllers/part1/Part01Step26ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part1/Part01Step26ControllerTest.java
@@ -151,7 +151,7 @@ public class Part01Step26ControllerTest extends AbstractControllerTest {
         when(dataRepository.getObdModules()).thenReturn(List.of(obdModule));
         when(obdModule.getSourceAddress()).thenReturn(0);
         List<SupportedSPN> supportedSPNList = spns(111, 222, 333, 444, 555, 666, 777, 888, 999);
-        when(obdModule.getDataStreamSpns()).thenReturn(supportedSPNList);
+        when(obdModule.getFilteredDataStreamSPNs()).thenReturn(supportedSPNList);
 
         when(broadcastValidator.getMaximumBroadcastPeriod()).thenReturn(3);
 
@@ -311,7 +311,7 @@ public class Part01Step26ControllerTest extends AbstractControllerTest {
         when(dataRepository.getObdModules()).thenReturn(List.of(obdModule));
         when(obdModule.getSourceAddress()).thenReturn(0);
         List<SupportedSPN> supportedSPNList = spns(111, 444);
-        when(obdModule.getDataStreamSpns()).thenReturn(supportedSPNList);
+        when(obdModule.getFilteredDataStreamSPNs()).thenReturn(supportedSPNList);
 
         when(broadcastValidator.getMaximumBroadcastPeriod()).thenReturn(3);
 

--- a/src-test/org/etools/j1939_84/model/OBDModuleInformationTest.java
+++ b/src-test/org/etools/j1939_84/model/OBDModuleInformationTest.java
@@ -12,8 +12,10 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.etools.j1939_84.bus.j1939.packets.CompositeSystem;
 import org.etools.j1939_84.bus.j1939.packets.DM19CalibrationInformationPacket.CalibrationInformation;
 import org.etools.j1939_84.bus.j1939.packets.MonitoredSystem;
@@ -45,7 +47,9 @@ public class OBDModuleInformationTest {
             SupportedSPN supportedSpn = new SupportedSPN(data);
             supportedSpnsList.add(supportedSpn);
         }
-        return supportedSpnsList;
+        return supportedSpnsList.stream()
+                .sorted(Comparator.comparingInt(SupportedSPN::getSpn))
+                .collect(Collectors.toList());
     }
 
     private OBDModuleInformation instance;
@@ -68,10 +72,10 @@ public class OBDModuleInformationTest {
         instance.setCalibrationInformation(List.of(calInfo));
 
         MonitoredSystem monitoredSystem = new MonitoredSystem("test",
-                                                   NOT_SUPPORTED_COMPLETE,
-                                                   0,
-                                                   CompositeSystem.CATALYST,
-                                                   true);
+                                                              NOT_SUPPORTED_COMPLETE,
+                                                              0,
+                                                              CompositeSystem.CATALYST,
+                                                              true);
         instance.setMonitoredSystems(Set.of(monitoredSystem));
 
         PerformanceRatio performanceRatio = new PerformanceRatio(999, 0, 25, 50);
@@ -110,9 +114,9 @@ public class OBDModuleInformationTest {
     @Test
     public void testGetDataStreamSpns() {
         List<SupportedSPN> expectedSPNs = new ArrayList<>();
-        SupportedSPN supportedSpn = new SupportedSPN(new int[] { 0x01, 0x02, 0x1D, 8 });
-        SupportedSPN supportedSpn2 = new SupportedSPN(new int[] { 0x00, 0x00, 0x00, 0x00 });
-        expectedSPNs.add(supportedSpn);
+        SupportedSPN supportedSpn1 = new SupportedSPN(new int[] { 0x00, 0x00, 0x00, 0x00 });
+        SupportedSPN supportedSpn2 = new SupportedSPN(new int[] { 0x01, 0x02, 0x1D, 8 });
+        expectedSPNs.add(supportedSpn1);
         expectedSPNs.add(supportedSpn2);
         assertEquals("GetDataStreamSpn", expectedSPNs, instance.getDataStreamSpns());
     }
@@ -201,7 +205,7 @@ public class OBDModuleInformationTest {
         expectedObd += "Performance Ratios: [SPN  999 Trip Gear Down Distance: 0 / 25]" + NL;
         expectedObd += "Monitored Systems: [    test not supported,     complete]" + NL;
         expectedObd += "Supported SPNs: " + NL;
-        expectedObd += "SPN 513 - Actual Engine - Percent Torque,SPN 0 - Unknown,SPN 524030 - Manufacturer Assignable SPN";
+        expectedObd += "SPN 0 - Unknown, SPN 513 - Actual Engine - Percent Torque, SPN 524030 - Manufacturer Assignable SPN";
         assertEquals(expectedObd, instance.toString());
     }
 

--- a/src/org/etools/j1939_84/controllers/part1/BroadcastValidator.java
+++ b/src/org/etools/j1939_84/controllers/part1/BroadcastValidator.java
@@ -70,7 +70,7 @@ public class BroadcastValidator {
     public int getMaximumBroadcastPeriod() {
         return Math.max(dataRepository.getObdModules()
                 .stream()
-                .flatMap(m -> m.getDataStreamSpns().stream())
+                .flatMap(m -> m.getFilteredDataStreamSPNs().stream())
                 .map(SupportedSPN::getSpn)
                 .map(j1939DaRepository::getPgnForSpn)
                 .filter(Objects::nonNull)

--- a/src/org/etools/j1939_84/controllers/part1/Part01Step26Controller.java
+++ b/src/org/etools/j1939_84/controllers/part1/Part01Step26Controller.java
@@ -247,7 +247,7 @@ public class Part01Step26Controller extends StepController {
         // Collect all the Data Stream Supported SPNs from all OBD Modules.
         List<Integer> supportedSPNs = dataRepository.getObdModules()
                 .stream()
-                .flatMap(m -> m.getDataStreamSpns().stream())
+                .flatMap(m -> m.getFilteredDataStreamSPNs().stream())
                 .map(SupportedSPN::getSpn)
                 .collect(Collectors.toList());
 
@@ -319,7 +319,7 @@ public class Part01Step26Controller extends StepController {
             int moduleAddress = obdModule.getSourceAddress();
 
             // Get the SPNs which are supported by the module
-            List<Integer> dataStreamSPNs = obdModule.getDataStreamSpns()
+            List<Integer> dataStreamSPNs = obdModule.getFilteredDataStreamSPNs()
                     .stream()
                     .map(SupportedSPN::getSpn)
                     .collect(Collectors.toList());


### PR DESCRIPTION
In the `OBDModuleInformation` I added a list of SPNs which will be filtered out of the data stream SPNs for that module.  This list starts with Eric's provided numbers. 

In the `TableA1Validator` as the expected messages are being reported, the list of SPNs supported by the module, but omitted is written to the log.  In additions, as the other SPNs are being processed to find the PGNs they are in, if additional SPs are found to be in multiple PGs, they will be added to the `omittedSPNsList` in the `OBDModuleInformation` and will be omitted in future runs.  Additionally, their omission is noted in the log.