### PR TITLE
Fix #538 Log when Vehicle Information can't be gathered

### DIFF
--- a/src-test/org/etools/j1939_84/modules/VehicleInformationModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/VehicleInformationModuleTest.java
@@ -461,7 +461,7 @@ public class VehicleInformationModuleTest {
                            packet3.getPacket())).when(j1939).read(anyLong(), any());
 
 
-        List<Integer> results = instance.getOBDModules();
+        List<Integer> results = instance.getOBDModules(NOOP);
         assertEquals(2, results.size());
         assertTrue(results.contains(0x00));
         assertTrue(results.contains(0x21));

--- a/src-test/org/etools/j1939_84/ui/UserInterfacePresenterTest.java
+++ b/src-test/org/etools/j1939_84/ui/UserInterfacePresenterTest.java
@@ -626,6 +626,7 @@ public class UserInterfacePresenterTest {
         verify(view).setSelectFileButtonEnabled(false);
         verify(view).setStopButtonEnabled(true);
         verify(view).setAdapterComboBoxEnabled(false);
+        verify(reportFileModule).setJ1939(any(J1939.class));
     }
 
     @Test

--- a/src-test/org/etools/j1939_84/ui/VehicleInformationDialogTest.java
+++ b/src-test/org/etools/j1939_84/ui/VehicleInformationDialogTest.java
@@ -48,7 +48,7 @@ public class VehicleInformationDialogTest {
     @Test
     public void testSetVisibleTrue() throws InterruptedException {
         instance.setVisible(true);
-        // initialize runs in a thread. Give ti time to start.
+        // initialize runs in a thread. Give it time to start.
         Thread.sleep(500);
         verify(presenter).readVehicle();
     }

--- a/src-test/org/etools/j1939_84/ui/VehicleInformationDialogTest.java
+++ b/src-test/org/etools/j1939_84/ui/VehicleInformationDialogTest.java
@@ -50,7 +50,7 @@ public class VehicleInformationDialogTest {
         instance.setVisible(true);
         // initialize runs in a thread. Give ti time to start.
         Thread.sleep(500);
-        verify(presenter).initialize();
+        verify(presenter).readVehicle();
     }
 
 }

--- a/src-test/org/etools/j1939_84/ui/VehicleInformationPresenterTest.java
+++ b/src-test/org/etools/j1939_84/ui/VehicleInformationPresenterTest.java
@@ -3,6 +3,7 @@
  */
 package org.etools.j1939_84.ui;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -25,7 +26,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -79,10 +79,10 @@ public class VehicleInformationPresenterTest {
         when(vehicleInformationModule.reportAddressClaim(resultsListener)).thenReturn(RequestResult.empty());
         when(vehicleInformationModule.getEngineModelYear()).thenReturn(4);
         when(vehicleInformationModule.getEngineFamilyName()).thenReturn("family");
-        when(vehicleInformationModule.getOBDModules()).thenReturn(List.of());
+        when(vehicleInformationModule.getOBDModules(any())).thenReturn(List.of());
         when(listener.getResultsListener()).thenReturn(resultsListener);
 
-        instance.initialize();
+        instance.readVehicle();
 
         verify(listener).getResultsListener();
         verify(vehicleInformationModule).getVin();
@@ -96,11 +96,11 @@ public class VehicleInformationPresenterTest {
         verify(view).setCalIds(0);
         verify(vehicleInformationModule).getEngineModelYear();
         verify(view).setEngineModelYear(4);
-        verify(vehicleInformationModule).reportAddressClaim(ArgumentMatchers.any());
-        verify(vehicleInformationModule).reportCalibrationInformation(ArgumentMatchers.any());
+        verify(vehicleInformationModule).reportAddressClaim(any());
+        verify(vehicleInformationModule).reportCalibrationInformation(any());
         verify(vehicleInformationModule).getEngineFamilyName();
         verify(view).setCertificationIntent("family");
-        verify(vehicleInformationModule).getOBDModules();
+        verify(vehicleInformationModule).getOBDModules(any());
     }
 
     @Test
@@ -115,10 +115,10 @@ public class VehicleInformationPresenterTest {
         when(vehicleInformationModule.reportAddressClaim(resultsListener)).thenReturn(RequestResult.empty());
         when(vehicleInformationModule.getEngineModelYear()).thenThrow(new IOException());
         when(vehicleInformationModule.getEngineFamilyName()).thenThrow(new IOException());
-        when(vehicleInformationModule.getOBDModules()).thenReturn(List.of());
+        when(vehicleInformationModule.getOBDModules(any())).thenReturn(List.of());
         when(listener.getResultsListener()).thenReturn(resultsListener);
 
-        instance.initialize();
+        instance.readVehicle();
 
         verify(listener).getResultsListener();
         verify(vehicleInformationModule).getVin();
@@ -131,11 +131,11 @@ public class VehicleInformationPresenterTest {
         verify(dateTimeModule).getYear();
         verify(view).setVehicleModelYear(500);
         verify(view).setEngineModelYear(500);
-        verify(vehicleInformationModule).reportAddressClaim(ArgumentMatchers.any());
-        verify(vehicleInformationModule).reportCalibrationInformation(ArgumentMatchers.any());
+        verify(vehicleInformationModule).reportAddressClaim(any());
+        verify(vehicleInformationModule).reportCalibrationInformation(any());
         verify(vehicleInformationModule).getEngineModelYear();
         verify(vehicleInformationModule).getEngineFamilyName();
-        verify(vehicleInformationModule).getOBDModules();
+        verify(vehicleInformationModule).getOBDModules(any());
     }
 
     @Test

--- a/src/org/etools/j1939_84/modules/VehicleInformationModule.java
+++ b/src/org/etools/j1939_84/modules/VehicleInformationModule.java
@@ -128,13 +128,13 @@ public class VehicleInformationModule extends FunctionalModule {
                     .flatMap(e -> e.left.stream())
                     .map(DM56EngineFamilyPacket::getFamilyName)
                     .collect(Collectors.toSet());
-            // FIXME what about NACKS?
             if (results.size() == 0) {
                 throw new IOException("Timeout Error Reading Engine Family");
             } else if (results.size() > 1) {
                 throw new IOException("Different Engine Families Received");
+            } else {
+                engineFamilyName = results.stream().findFirst().get();
             }
-            engineFamilyName = results.stream().findFirst().get();
         }
         return engineFamilyName;
     }
@@ -155,13 +155,13 @@ public class VehicleInformationModule extends FunctionalModule {
                     .flatMap(e -> e.left.stream())
                     .map(DM56EngineFamilyPacket::getEngineModelYear)
                     .collect(Collectors.toSet());
-            // FIXME what about NACKS
             if (results.size() == 0) {
                 throw new IOException("Timeout Error Reading Engine Model Year");
             } else if (results.size() > 1) {
                 throw new IOException("Different Engine Model Years Received");
+            } else {
+                engineModelYear = results.stream().findFirst().get();
             }
-            engineModelYear = results.stream().findFirst().get();
         }
         return engineModelYear;
     }

--- a/src/org/etools/j1939_84/ui/UserInterfacePresenter.java
+++ b/src/org/etools/j1939_84/ui/UserInterfacePresenter.java
@@ -441,8 +441,10 @@ public class UserInterfacePresenter implements UserInterfaceContract.Presenter {
         getView().setReadVehicleInfoButtonEnabled(false);
         getView().setSelectFileButtonEnabled(false);
         getView().setAdapterComboBoxEnabled(false);
-        getReportFileModule().setJ1939(j1939);
-        overallController.execute(getResultsListener(), getNewJ1939(), getReportFileModule());
+
+        J1939 newJ1939 = getNewJ1939();
+        overallController.execute(getResultsListener(), newJ1939, getReportFileModule());
+        getReportFileModule().setJ1939(newJ1939);
     }
 
     /*

--- a/src/org/etools/j1939_84/ui/VehicleInformationContract.java
+++ b/src/org/etools/j1939_84/ui/VehicleInformationContract.java
@@ -20,7 +20,7 @@ public interface VehicleInformationContract {
          * Called to initialize the presenter. This should be called when the
          * dialog is created/displayed
          */
-        void initialize();
+        void readVehicle();
 
         /**
          * Called when the Emissions Unit count changes

--- a/src/org/etools/j1939_84/ui/VehicleInformationDialog.java
+++ b/src/org/etools/j1939_84/ui/VehicleInformationDialog.java
@@ -563,10 +563,10 @@ public class VehicleInformationDialog extends JDialog implements VehicleInformat
     }
 
     @Override
-    public void setVisible(boolean b) {
-        super.setVisible(b);
-        if (b) {
-            new Thread(presenter::initialize).start();
+    public void setVisible(boolean isVisible) {
+        super.setVisible(isVisible);
+        if (isVisible) {
+            new Thread(presenter::readVehicle).start();
         } else {
             super.dispose();
             dispatchEvent(new WindowEvent(this, WindowEvent.WINDOW_CLOSING));

--- a/src/org/etools/j1939_84/ui/VehicleInformationPresenter.java
+++ b/src/org/etools/j1939_84/ui/VehicleInformationPresenter.java
@@ -171,28 +171,6 @@ public class VehicleInformationPresenter implements VehicleInformationContract.P
         view.setNumberOfTripsForFaultBImplant(numberOfTripsForFaultBImplant);
 
         try {
-            List<Integer> obdModules = vehicleInformationModule.getOBDModules(NOOP);
-            view.setEmissionUnits(obdModules.size());
-
-            emissionUnitsFound = obdModules
-                    .stream().map(address -> vehicleInformationModule.reportComponentIdentification(NOOP, address)
-                            .getPacket()
-                            .map(e -> e.resolve(p -> p,
-                                                ack -> create(address, "ERROR", "ERROR", "ERROR", "ERROR")))
-                            .orElse(create(address, "MISSING", "MISSING", "MISSING", "MISSING")))
-                    .collect(Collectors.toList());
-        } catch (Exception e) {
-            getLogger().log(INFO, "Error reading getting OBD Modules", e);
-        }
-
-        try {
-            calIdsFound = vehicleInformationModule.reportCalibrationInformation(NOOP);
-            view.setCalIds((int) calIdsFound.stream().mapToLong(p -> p.getCalibrationInformation().size()).sum());
-        } catch (Exception e) {
-            getLogger().log(INFO, "Error reading calibration IDs", e);
-        }
-
-        try {
             vin = vehicleInformationModule.getVin();
             view.setVin(vin);
         } catch (Exception e) {
@@ -219,6 +197,29 @@ public class VehicleInformationPresenter implements VehicleInformationContract.P
         } catch (Exception e) {
             getLogger().log(INFO, "Error reading engine family", e);
         }
+
+        try {
+            List<Integer> obdModules = vehicleInformationModule.getOBDModules(NOOP);
+            view.setEmissionUnits(obdModules.size());
+
+            emissionUnitsFound = obdModules
+                    .stream().map(address -> vehicleInformationModule.reportComponentIdentification(NOOP, address)
+                            .getPacket()
+                            .map(e -> e.resolve(p -> p,
+                                                ack -> create(address, "ERROR", "ERROR", "ERROR", "ERROR")))
+                            .orElse(create(address, "MISSING", "MISSING", "MISSING", "MISSING")))
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            getLogger().log(INFO, "Error reading getting OBD Modules", e);
+        }
+
+        try {
+            calIdsFound = vehicleInformationModule.reportCalibrationInformation(NOOP);
+            view.setCalIds((int) calIdsFound.stream().mapToLong(p -> p.getCalibrationInformation().size()).sum());
+        } catch (Exception e) {
+            getLogger().log(INFO, "Error reading calibration IDs", e);
+        }
+
     }
 
     @Override


### PR DESCRIPTION
Rather than ignoring the exceptions from reading the vehicle, write them to the logger.