### PR TITLE
Fix #540 - Use different timeout with global requests and log the time we waited in the report

### DIFF
--- a/src-test/org/etools/j1939_84/modules/DiagnosticMessageModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/DiagnosticMessageModuleTest.java
@@ -160,7 +160,7 @@ public class DiagnosticMessageModuleTest {
         expected += "10:15:30.0000 Clearing Diagnostic Trouble Codes" + NL;
         expected += "10:15:30.0000 Global DM11 Request" + NL;
         expected += "10:15:30.0000 18EAFFA5 [3] D3 FE 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
         expected += "ERROR: Clearing Diagnostic Trouble Codes failed." + NL;
 
         TestResultsListener listener = new TestResultsListener();
@@ -213,7 +213,7 @@ public class DiagnosticMessageModuleTest {
         expected += "10:15:30.0000 Clearing Diagnostic Trouble Codes" + NL;
         expected += "10:15:30.0000 Global DM11 Request" + NL;
         expected += "10:15:30.0000 18EAFFA5 [3] D3 FE 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
         expected += "ERROR: Clearing Diagnostic Trouble Codes failed." + NL;
         assertEquals(expected, listener.getResults());
 
@@ -388,7 +388,7 @@ public class DiagnosticMessageModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Destination Specific DM12 Request to Instrument Cluster #1 (23)" + NL;
         expected += "10:15:30.0000 18EA17A5 [3] D4 FE 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         TestResultsListener listener = new TestResultsListener();
         BusResult<DM12MILOnEmissionDTCPacket> expectedResult = new BusResult<>(false, Optional.empty());
@@ -490,7 +490,7 @@ public class DiagnosticMessageModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Global DM12 Request" + NL;
         expected += "10:15:30.0000 18EAFFA5 [3] D4 FE 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         assertEquals(RequestResult.empty(false), instance.requestDM12(listener));
         assertEquals(expected, listener.getResults());
@@ -509,7 +509,7 @@ public class DiagnosticMessageModuleTest {
 
         String expected = "10:15:30.0000 Destination Specific DM21 Request to Engine #1 (0)" + NL;
         expected += "10:15:30.0000 18EA00A5 [3] 00 C1 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         TestResultsListener listener = new TestResultsListener();
         RequestResult<DM21DiagnosticReadinessPacket> result = new RequestResult<>(false);
@@ -703,7 +703,7 @@ public class DiagnosticMessageModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Destination Specific DM23 Request to Instrument Cluster #1 (23)" + NL;
         expected += "10:15:30.0000 18EA17A5 [3] B5 FD 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         TestResultsListener listener = new TestResultsListener();
         BusResult<DM23PreviouslyMILOnEmissionDTCPacket> expectedResult = new BusResult<>(false, Optional.empty());
@@ -808,7 +808,7 @@ public class DiagnosticMessageModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Global DM23 Request" + NL;
         expected += "10:15:30.0000 18EAFFA5 [3] B5 FD 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         TestResultsListener listener = new TestResultsListener();
         assertEquals(RequestResult.empty(false), instance.requestDM23(listener));
@@ -857,7 +857,7 @@ public class DiagnosticMessageModuleTest {
         doReturn(Stream.empty(), Stream.empty(), Stream.empty()).when(j1939).read(anyLong(), any());
         String expected = "10:15:30.0000 Destination Specific DM25 Request to Engine #1 (0)" + NL;
         expected += "10:15:30.0000 18EA00A5 [3] B7 FD 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         TestResultsListener listener = new TestResultsListener();
         BusResult<DM25ExpandedFreezeFrame> expectedResult = new BusResult<>(false, Optional.empty());
@@ -999,7 +999,7 @@ public class DiagnosticMessageModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Destination Specific DM26 Request to Instrument Cluster #1 (23)" + NL;
         expected += "10:15:30.0000 18EA17A5 [3] B8 FD 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         TestResultsListener listener = new TestResultsListener();
         RequestResult<DM26TripDiagnosticReadinessPacket> expectedResult = new RequestResult<>(false,
@@ -1099,7 +1099,7 @@ public class DiagnosticMessageModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Global DM26 Request" + NL;
         expected += "10:15:30.0000 18EAFFA5 [3] B8 FD 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         TestResultsListener listener = new TestResultsListener();
         assertEquals(RequestResult.empty(false), instance.requestDM26(listener));
@@ -1199,7 +1199,7 @@ public class DiagnosticMessageModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Destination Specific DM27 Request to Instrument Cluster #1 (23)" + NL;
         expected += "10:15:30.0000 18EA17A5 [3] 82 FD 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         TestResultsListener listener = new TestResultsListener();
         BusResult<DM27AllPendingDTCsPacket> expectedResult = new BusResult<>(false, Optional.empty());
@@ -1310,7 +1310,7 @@ public class DiagnosticMessageModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Global DM27 Request" + NL;
         expected += "10:15:30.0000 18EAFFA5 [3] 82 FD 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         TestResultsListener listener = new TestResultsListener();
         assertEquals(RequestResult.empty(false), instance.requestDM27(listener));
@@ -1376,7 +1376,7 @@ public class DiagnosticMessageModuleTest {
 
         String expected = "10:15:30.0000 Destination Specific DM29 Request to Engine #1 (0)" + NL;
         expected += "10:15:30.0000 18EA00A5 [3] 00 9E 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response."
+        expected += "10:15:30.0000 Error: Timeout - No Response."
                 + NL;
 
         doReturn(Stream.empty(), Stream.empty(), Stream.empty()).when(j1939).read(anyLong(), any());
@@ -1429,7 +1429,7 @@ public class DiagnosticMessageModuleTest {
 
         String expected = "10:15:30.0000 Global DM29 Request" + NL;
         expected += "10:15:30.0000 18EAFFA5 [3] 00 9E 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         doReturn(Stream.empty(), Stream.empty(), Stream.empty()).when(j1939).read(anyLong(), any());
 
@@ -1487,7 +1487,7 @@ public class DiagnosticMessageModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Destination Specific DM2 Request to Instrument Cluster #1 (23)" + NL;
         expected += "10:15:30.0000 18EA17A5 [3] CB FE 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         TestResultsListener listener = new TestResultsListener();
         assertTrue(instance.requestDM2(listener, 0x17).getPacket().isEmpty());
@@ -1632,7 +1632,7 @@ public class DiagnosticMessageModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Global DM2 Request" + NL;
         expected += "10:15:30.0000 18EAFFA5 [3] CB FE 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         TestResultsListener listener = new TestResultsListener();
         assertEquals(new ArrayList<DM2PreviouslyActiveDTC>(), instance.requestDM2(listener).getPackets());
@@ -1652,7 +1652,7 @@ public class DiagnosticMessageModuleTest {
 
         String expected = "10:15:30.0000 Destination Specific DM31 Request to Engine #1 (0)" + NL;
         expected += "10:15:30.0000 18EA00A5 [3] 00 A3 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         doReturn(Stream.empty(), Stream.empty(), Stream.empty()).when(j1939).read(anyLong(), any());
 
@@ -1731,7 +1731,7 @@ public class DiagnosticMessageModuleTest {
 
         String expected = "10:15:30.0000 Global DM31 Request" + NL;
         expected += "10:15:30.0000 18EAFFA5 [3] 00 A3 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         doReturn(Stream.empty(), Stream.empty(), Stream.empty()).when(j1939).read(anyLong(), any());
 
@@ -1853,7 +1853,7 @@ public class DiagnosticMessageModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Destination Specific DM33 Request to Engine #1 (0)" + NL;
         expected += "10:15:30.0000 18EA00A5 [3] 00 A1 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         TestResultsListener listener = new TestResultsListener();
         var expectedResult = new RequestResult<>(false);
@@ -1914,7 +1914,7 @@ public class DiagnosticMessageModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Global DM33 Request" + NL;
         expected += "10:15:30.0000 18EAFFA5 [3] 00 A1 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         TestResultsListener listener = new TestResultsListener();
         assertEquals(RequestResult.empty(false), instance.requestDM33(listener));
@@ -2014,7 +2014,7 @@ public class DiagnosticMessageModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Destination Specific DM6 Request to Body Controller (33)" + NL;
         expected += "10:15:30.0000 18EA21A5 [3] CF FE 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         TestResultsListener listener = new TestResultsListener();
         RequestResult<DM6PendingEmissionDTCPacket> result = new RequestResult<>(false,
@@ -2118,7 +2118,7 @@ public class DiagnosticMessageModuleTest {
 
         String expected = "10:15:30.0000 Global DM6 Request" + NL;
         expected += "10:15:30.0000 18EAFFA5 [3] CF FE 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         TestResultsListener listener = new TestResultsListener();
         assertEquals(RequestResult.empty(false), instance.requestDM6(listener));

--- a/src-test/org/etools/j1939_84/modules/DiagnosticReadinessModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/DiagnosticReadinessModuleTest.java
@@ -114,7 +114,7 @@ public class DiagnosticReadinessModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Global DM20 Request" + NL;
         expected += "10:15:30.0000 18EAFFA5 [3] 00 C2 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
         instance.requestDM20(listener);
         assertEquals(expected, listener.getResults());
 
@@ -224,7 +224,7 @@ public class DiagnosticReadinessModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Destination Specific DM21 Request to Instrument Cluster #1 (23)" + NL;
         expected += "10:15:30.0000 18EA17A5 [3] 00 C1 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         instance.requestDM21(listener, 0x17);
         assertEquals(expected, listener.getResults());
@@ -275,7 +275,7 @@ public class DiagnosticReadinessModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Global DM21 Request" + NL;
         expected += "10:15:30.0000 18EAFFA5 [3] 00 C1 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
         instance.requestDM21(listener);
         assertEquals(expected, listener.getResults());
 
@@ -426,7 +426,7 @@ public class DiagnosticReadinessModuleTest {
         String expected = "";
         expected += "10:15:30.0000 Global DM5 Request" + NL;
         expected += "10:15:30.0000 18EAFFA5 [3] CE FE 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
         instance.requestDM5(listener);
         assertEquals(expected, listener.getResults());
 

--- a/src-test/org/etools/j1939_84/modules/VehicleInformationModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/VehicleInformationModuleTest.java
@@ -433,7 +433,7 @@ public class VehicleInformationModuleTest {
 
         String expected = "10:15:30.0000 Global VIN Request" + NL;
         expected += "10:15:30.0000 18EAFFA5 [3] EC FE 00 (TX)" + NL;
-        expected += "Error: Timeout - No Response." + NL;
+        expected += "10:15:30.0000 Error: Timeout - No Response." + NL;
 
         List<VehicleIdentificationPacket> packets = instance.reportVin(listener);
         assertEquals(0, packets.size());

--- a/src/org/etools/j1939_84/bus/Packet.java
+++ b/src/org/etools/j1939_84/bus/Packet.java
@@ -7,10 +7,13 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.etools.j1939_84.J1939_84;
 import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.modules.DateTimeModule;
@@ -45,11 +48,11 @@ public class Packet {
      * Creates an instance of Packet
      *
      * @param id
-     *         the ID of the packet
+     *            the ID of the packet
      * @param source
-     *         the source address of the packet
+     *            the source address of the packet
      * @param bytes
-     *         the data bytes of the packet
+     *            the data bytes of the packet
      * @return Packet
      */
     public static Packet create(int id, int source, byte... bytes) {
@@ -60,11 +63,11 @@ public class Packet {
      * Creates an instance of Packet
      *
      * @param id
-     *         the ID of the packet
+     *            the ID of the packet
      * @param source
-     *         the source address of the packet
+     *            the source address of the packet
      * @param data
-     *         the data of the packet
+     *            the data of the packet
      * @return Packet
      */
     public static Packet create(int id, int source, int... data) {
@@ -75,15 +78,15 @@ public class Packet {
      * Creates an instance of Packet
      *
      * @param priority
-     *         the priority of the packet
+     *            the priority of the packet
      * @param id
-     *         the ID of the packet
+     *            the ID of the packet
      * @param source
-     *         the source address of the packet
+     *            the source address of the packet
      * @param transmitted
-     *         indicates the packet was sent by the application
+     *            indicates the packet was sent by the application
      * @param bytes
-     *         the data bytes of the packet
+     *            the data bytes of the packet
      * @return Packet
      */
     public static Packet create(int priority, int id, int source, boolean transmitted, byte... bytes) {
@@ -107,7 +110,7 @@ public class Packet {
      * Converts the value produced by Packet.toString() back into a Packet
      *
      * @param string
-     *         the {@link String} to parse
+     *            the {@link String} to parse
      * @return a Packet or null if the string could not be parsed
      */
     public static Packet parse(String string) {
@@ -144,9 +147,9 @@ public class Packet {
         String[] a = p.split("[,\\s]+");
         int id = Integer.parseInt(a[0], 16);
         return Packet.create(0xFFFFFF & (id >> 8),
-                             0xFF & id,
-                             Stream.of(Arrays.copyOfRange(a, 1, a.length, String[].class))
-                                     .mapToInt(s -> Integer.parseInt(s, 16)).toArray());
+                0xFF & id,
+                Stream.of(Arrays.copyOfRange(a, 1, a.length, String[].class))
+                        .mapToInt(s -> Integer.parseInt(s, 16)).toArray());
     }
 
     public static Packet parseVector(LocalDateTime start, String line) {
@@ -155,17 +158,19 @@ public class Packet {
             int id = Integer.parseInt(a[2].substring(0, a[2].length() - 1), 16);
 
             return new Packet(start.plusNanos((long) (Double.parseDouble(a[0]) * 1000000000)),
-                              6,
-                              0xFFFFFF & (id >> 8),
-                              0xFF & id,
-                              false,
-                              Stream.of(Arrays.copyOfRange(a, 6, 6 + Integer.parseInt(a[5]), String[].class))
-                                      .mapToInt(s -> Integer.parseInt(s, 16)).toArray());
+                    6,
+                    0xFFFFFF & (id >> 8),
+                    0xFF & id,
+                    false,
+                    Stream.of(Arrays.copyOfRange(a, 6, 6 + Integer.parseInt(a[5]), String[].class))
+                            .mapToInt(s -> Integer.parseInt(s, 16)).toArray());
         }
         return null;
     }
 
     private int[] data;
+
+    private List<Packet> fragments = Collections.emptyList();
 
     private final int id;
 
@@ -181,15 +186,15 @@ public class Packet {
      * Creates a Packet
      *
      * @param priority
-     *         the priority of the packet
+     *            the priority of the packet
      * @param id
-     *         the ID of the packet
+     *            the ID of the packet
      * @param source
-     *         the source address of the packet
+     *            the source address of the packet
      * @param transmitted
-     *         indicates the packet was sent by the application
+     *            indicates the packet was sent by the application
      * @param data
-     *         the data of the packet
+     *            the data of the packet
      */
     private Packet(LocalDateTime timestamp, int priority, int id, int source, boolean transmitted, int... data) {
         this.timestamp = timestamp;
@@ -228,7 +233,7 @@ public class Packet {
      * Returns one byte (8-bits) from the data at the given index
      *
      * @param i
-     *         the index
+     *            the index
      * @return int
      */
     public int get(int i) {
@@ -239,7 +244,7 @@ public class Packet {
      * Returns two bytes (16-bits) from the data at the given index and index+1
      *
      * @param i
-     *         the index
+     *            the index
      * @return int
      */
     public int get16(int i) {
@@ -251,7 +256,7 @@ public class Packet {
      * given index and index+1
      *
      * @param i
-     *         the index
+     *            the index
      * @return int
      */
     public int get16Big(int i) {
@@ -263,7 +268,7 @@ public class Packet {
      * and index+2
      *
      * @param i
-     *         the index
+     *            the index
      * @return int
      */
     public int get24(int i) {
@@ -275,7 +280,7 @@ public class Packet {
      * given index, index+1, and index+2
      *
      * @param i
-     *         the index
+     *            the index
      * @return int
      */
     public int get24Big(int i) {
@@ -287,12 +292,12 @@ public class Packet {
      * index+2, and index+3
      *
      * @param i
-     *         the index
+     *            the index
      * @return int
      */
     public long get32(int i) {
-        return ((long) (getData()[i + 3] & 0xFF) << 24) | ((getData()[i + 2] & 0xFF) << 16) | ((getData()[i + 1] & 0xFF) << 8)
-                | (getData()[i] & 0xFF);
+        return ((long) (getData()[i + 3] & 0xFF) << 24) | ((getData()[i + 2] & 0xFF) << 16)
+                | ((getData()[i + 1] & 0xFF) << 8) | (getData()[i] & 0xFF);
     }
 
     /**
@@ -300,11 +305,12 @@ public class Packet {
      * given index, index+1, index+2, and index+3
      *
      * @param i
-     *         the index
+     *            the index
      * @return int
      */
     public long get32Big(int i) {
-        return ((long) getData()[i] << 24) | ((long) getData()[i + 1] << 16) | ((long) getData()[i + 2] << 8) | getData()[i + 3];
+        return ((long) getData()[i] << 24) | ((long) getData()[i + 1] << 16) | ((long) getData()[i + 2] << 8)
+                | getData()[i + 3];
     }
 
     public long get64() {
@@ -342,9 +348,9 @@ public class Packet {
      * Returns the data from the beginIndex to the endIndex (inclusive).
      *
      * @param beginIndex
-     *         the first data value to return
+     *            the first data value to return
      * @param endIndex
-     *         the last data value to return
+     *            the last data value to return
      * @return int[]
      */
     public int[] getData(int beginIndex, int endIndex) {
@@ -360,11 +366,15 @@ public class Packet {
         return getId(0xFFFF) < 0xF000 ? getId(0xFF) : J1939.GLOBAL_ADDR;
     }
 
+    public List<Packet> getFragments() {
+        return fragments;
+    }
+
     /**
      * Returns the ID of the packet
      *
      * @param mask
-     *         Because the whole id rarely ever used, provide the mask.
+     *            Because the whole id rarely ever used, provide the mask.
      * @return int
      */
     public int getId(int mask) {
@@ -445,6 +455,10 @@ public class Packet {
         notifyAll();
     }
 
+    public void setFragments(List<Packet> fragments) {
+        this.fragments = fragments;
+    }
+
     public void setTimestamp(LocalDateTime timestamp2) {
         timestamp = timestamp2;
     }
@@ -452,13 +466,13 @@ public class Packet {
     @Override
     public String toString() {
         return String.format("%06X%02X [%s] %s",
-                             priority << 18 | id,
-                             source,
-                             getLength(),
-                             Arrays.stream(getData())
-                                     .mapToObj(x -> String.format("%02X", x))
-                                     .collect(Collectors.joining(" "))
-                                     + (transmitted ? TX : RX));
+                priority << 18 | id,
+                source,
+                getLength(),
+                Arrays.stream(getData())
+                        .mapToObj(x -> String.format("%02X", x))
+                        .collect(Collectors.joining(" "))
+                        + (transmitted ? TX : RX));
     }
 
     /**

--- a/src/org/etools/j1939_84/bus/j1939/J1939.java
+++ b/src/org/etools/j1939_84/bus/j1939/J1939.java
@@ -74,15 +74,15 @@ public class J1939 {
 
     /**
      * The default time to wait for a response from a destination specific request (200 ms + 10% + fudge factor)
-     * These times come from J1939-21, 5.12.3 Device Response Time and Timeout Defaults
+     * This time come from J1939-21, 5.12.3 Device Response Time and Timeout Defaults
      */
-    private static final int DS_TIMEOUT = 230;
+    private static final int DS_TIMEOUT = 230; // milliseconds
 
     /**
-     * The default time to wait for a response from a global request (1.25 s)
-     * These times come from J1939-21, 5.12.3 Device Response Time and Timeout Defaults
+     * The default time to wait for a response from a global request
+     * This time come from Eric
      */
-    private static final int GLOBAL_TIMEOUT = 1250;
+    private static final int GLOBAL_TIMEOUT = 600; // milliseconds
 
     /**
      * The source address of the engine


### PR DESCRIPTION
1250 ms should be used as the timeout with Global Requests
200 ms should be used for DS requests