### PR TITLE
Fix #553 DM5 Active and Previously Active values are being improperly filtered

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step13ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step13ControllerTest.java
@@ -277,8 +277,12 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
-                                        "6.1.13.2.b - OBD ECU Engine #1 (0) reported active/previously active fault DTCs count not = 0/0" + NL
-                                                + "  Reported active fault count = 3" + NL + "  Reported previously active fault count = 16");
+                                        "6.1.13.2.b - OBD ECU Engine #1 (0) reported active DTC count not = 0");
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.1.13.2.b - OBD ECU Engine #1 (0) reported previously active DTC count not = 0");
 
         verify(mockListener).addOutcome(
                 1,
@@ -376,9 +380,8 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
                 "    Secondary air system       not supported,     complete" + NL;
 
         String expectedResults = expectedVehicleComposite + NL;
-        expectedResults += "FAIL: 6.1.13.2.b - OBD ECU Engine #1 (0) reported active/previously active fault DTCs count not = 0/0" + NL;
-        expectedResults += "  Reported active fault count = 3" + NL;
-        expectedResults += "  Reported previously active fault count = 16" + NL;
+        expectedResults += "FAIL: 6.1.13.2.b - OBD ECU Engine #1 (0) reported active DTC count not = 0" + NL;
+        expectedResults += "FAIL: 6.1.13.2.b - OBD ECU Engine #1 (0) reported previously active DTC count not = 0" + NL;
         expectedResults += "WARN: 6.1.13.2.d - Required monitor Boost pressure control sys is supported by more than one OBD ECU" + NL;
         expectedResults += "WARN: 6.1.13.2.d - Required monitor Diesel Particulate Filter is supported by more than one OBD ECU" + NL;
         expectedResults += "WARN: 6.1.13.2.d - Required monitor EGR/VVT system is supported by more than one OBD ECU" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step02ControllerTest.java
@@ -228,9 +228,7 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
-                                        "6.2.2.2.b - OBD ECU Engine #1 (0) reported active/previously active fault DTCs count not = 0/0" + NL +
-                                                "  Reported active fault count = 1" + NL +
-                                                "  Reported previously active fault count = 0");
+                                        "6.2.2.2.b - OBD ECU Engine #1 (0) reported active DTC count not = 0");
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         WARN,
@@ -262,9 +260,8 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
                 "    NMHC converting catalyst       supported, not complete" + NL +
                 "    NOx catalyst/adsorber          supported, not complete" + NL +
                 "    Secondary air system       not supported,     complete" + NL +
-                NL + "FAIL: 6.2.2.2.b - OBD ECU Engine #1 (0) reported active/previously active fault DTCs count not = 0/0" + NL +
-                "  Reported active fault count = 1" + NL +
-                "  Reported previously active fault count = 0" + NL +
+                NL +
+                "FAIL: 6.2.2.2.b - OBD ECU Engine #1 (0) reported active DTC count not = 0" + NL +
                 "WARN: 6.2.2.2.c - Required monitor Exhaust Gas Sensor heater is supported by more than one OBD ECU" + NL +
                 "FAIL: 6.2.2.4.a - Difference compared to data received during global request" + NL;
 


### PR DESCRIPTION
If the active count == 0xFF, then only it should be ignored, not the entire packet.