### PR TITLE
Fix #564 Part 1 Step 5: Invalid VINs should not cause other failures

### DIFF
--- a/src/org/etools/j1939_84/controllers/part01/Part01Step05Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step05Controller.java
@@ -7,6 +7,7 @@ import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 import org.etools.j1939_84.bus.j1939.packets.VehicleIdentificationPacket;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
+import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
 import org.etools.j1939_84.modules.DiagnosticMessageModule;
@@ -20,7 +21,6 @@ public class Part01Step05Controller extends StepController {
     private static final int STEP_NUMBER = 5;
     private static final int TOTAL_STEPS = 0;
 
-    private final DataRepository dataRepository;
     private final VinDecoder vinDecoder;
 
     Part01Step05Controller(DataRepository dataRepository) {
@@ -41,16 +41,16 @@ public class Part01Step05Controller extends StepController {
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
-              engineSpeedModule,
               bannerModule,
+              dateTimeModule,
+              dataRepository,
+              engineSpeedModule,
               vehicleInformationModule,
               new DiagnosticMessageModule(),
-              dateTimeModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);
         this.vinDecoder = vinDecoder;
-        this.dataRepository = dataRepository;
     }
 
     @Override
@@ -62,44 +62,45 @@ public class Part01Step05Controller extends StepController {
         }
 
         long obdResponses = packets.stream()
-                .filter(p -> dataRepository.getObdModuleAddresses().contains(p.getSourceAddress())).count();
+                .filter(p -> getDataRepository().isObdModule(p.getSourceAddress())).count();
         if (obdResponses > 1) {
-            addFailure(1, 5, "6.1.5.2.b - More than one OBD ECU responded with VIN");
+            addFailure("6.1.5.2.b - More than one OBD ECU responded with VIN");
         }
 
         VehicleIdentificationPacket packet = packets.get(0);
         String vin = packet.getVin();
-        if (!dataRepository.getVehicleInformation().getVin().equals(vin)) {
-            addFailure(1, 5, "6.1.5.2.c - VIN does not match user entered VIN");
-        }
+        VehicleInformation vehicleInformation = getDataRepository().getVehicleInformation();
 
-        if (vinDecoder.getModelYear(vin) != dataRepository.getVehicleInformation().getVehicleModelYear()) {
-            addFailure(1, 5, "6.1.5.2.d - VIN Model Year does not match user entered Vehicle Model Year");
+        if (!vehicleInformation.getVin().equals(vin)) {
+            addFailure("6.1.5.2.c - VIN does not match user entered VIN");
         }
 
         if (!vinDecoder.isVinValid(vin)) {
-            addFailure(1,
-                       5,
-                       "6.1.5.2.e - VIN is not valid (not 17 legal chars, incorrect checksum, or non-numeric sequence");
+            addFailure("6.1.5.2.e - VIN is not valid (not 17 legal chars, incorrect checksum, or non-numeric sequence");
+        } else {
+            if (vinDecoder.getModelYear(vin) != vehicleInformation.getVehicleModelYear()) {
+                addFailure("6.1.5.2.d - VIN Model Year does not match user entered Vehicle Model Year");
+            }
         }
 
         long nonObdResponses = packets.stream()
-                .filter(p -> !dataRepository.getObdModuleAddresses().contains(p.getSourceAddress())).count();
+                .filter(p -> !getDataRepository().isObdModule(p.getSourceAddress()))
+                .count();
         if (nonObdResponses > 0) {
-            addWarning(1, 5, "6.1.5.3.a - Non-OBD ECU responded with VIN");
+            addWarning("6.1.5.3.a - Non-OBD ECU responded with VIN");
         }
 
         long respondingSources = packets.stream().mapToInt(ParsedPacket::getSourceAddress).distinct().count();
         if (packets.size() > respondingSources) {
-            addWarning(1, 5, "6.1.5.3.b - More than one VIN response from an ECU");
+            addWarning("6.1.5.3.b - More than one VIN response from an ECU");
         }
 
         if (nonObdResponses > 1) {
-            addWarning(1, 5, "6.1.5.3.c - VIN provided from more than one non-OBD ECU");
+            addWarning("6.1.5.3.c - VIN provided from more than one non-OBD ECU");
         }
 
         if (!packet.getManufacturerData().isEmpty()) {
-            addWarning(1, 5, "6.1.5.3.d - Manufacturer defined data follows the VIN");
+            addWarning("6.1.5.3.d - Manufacturer defined data follows the VIN");
         }
     }
 


### PR DESCRIPTION
The `vinDecoder.getModelYear()` method shortcuts if the VIN is invalid.  Thus the tool is erroneously reporting a mismatch in the model year if the VIN is invalid.

This switches the order of the processing to not report a mis-matched model year if the VIN is invalid.